### PR TITLE
ヘルプカテゴリ・コンテンツ取得ロジックを実装 : frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2384,9 +2384,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/app/routes/helpCategory.tsx
+++ b/frontend/src/app/routes/helpCategory.tsx
@@ -25,13 +25,13 @@ export const HelpCategory = () => {
   return (
     <>
       <Header />
-      <div className={styles.wrapper}>
+      <main className={styles.main}>
         <h1>ヘルプ一覧</h1>
 
         <div className={styles.helpCategoryContainer}>
-          {helpCategory.map((item) => (
+          {helpCategory.map((item, index) => (
             <HelpCategoryCard
-              key={item.id}
+              key={item.id ?? index}
               title={item.categoryName}
               description={item.description}
               iconUrl={item.iconUrl}
@@ -39,7 +39,7 @@ export const HelpCategory = () => {
             />
           ))}
         </div>
-      </div>
+      </main>
     </>
   );
 };

--- a/frontend/src/app/routes/helpCategory.tsx
+++ b/frontend/src/app/routes/helpCategory.tsx
@@ -1,56 +1,41 @@
+import { useEffect, useState } from "react";
 import { HelpCategoryCard } from "@/features/help/components/helpCategory/helpCategoryCard";
-import Styles  from "@/features/help/styles/helpCategory.module.css"
+import styles from "@/features/help/styles/helpCategory.module.css";
 import { Header } from "@/components/ui/header/header";
-
-type HelpItem = {
-  id: number;
-  title: string;
-  description: string;
-  iconUrl?: string;
-}
-
-const HelpDataDummy: HelpItem[] = [
-  { 
-    id: 1,
-    title: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    description: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    iconUrl: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh992Feh17LdokXFmUpRtsZ_qW7TSbpui8Sz_Xh_RQpVQ98UpX304YmCm6YQF-d-eguV-I-2zdEel7gORrAEYWEEwxsv6vS_tn7hFwITDxNgzhf3c1p8biIIkClCw7ZyqBSEFMDL2smTSWJ/s180-c/figure_katagumi_friends.png",
-  },
-  {
-    id: 2,
-    title: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    description: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    iconUrl: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh992Feh17LdokXFmUpRtsZ_qW7TSbpui8Sz_Xh_RQpVQ98UpX304YmCm6YQF-d-eguV-I-2zdEel7gORrAEYWEEwxsv6vS_tn7hFwITDxNgzhf3c1p8biIIkClCw7ZyqBSEFMDL2smTSWJ/s180-c/figure_katagumi_friends.png",
-  },
-  {
-    id: 3,
-    title: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    description: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    iconUrl: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh992Feh17LdokXFmUpRtsZ_qW7TSbpui8Sz_Xh_RQpVQ98UpX304YmCm6YQF-d-eguV-I-2zdEel7gORrAEYWEEwxsv6vS_tn7hFwITDxNgzhf3c1p8biIIkClCw7ZyqBSEFMDL2smTSWJ/s180-c/figure_katagumi_friends.png",
-  },
-  {
-    id: 4,
-    title: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    description: "あいうえおあいうえおあいうえおあいうえおあいうえおあいうえお",
-    iconUrl: "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh992Feh17LdokXFmUpRtsZ_qW7TSbpui8Sz_Xh_RQpVQ98UpX304YmCm6YQF-d-eguV-I-2zdEel7gORrAEYWEEwxsv6vS_tn7hFwITDxNgzhf3c1p8biIIkClCw7ZyqBSEFMDL2smTSWJ/s180-c/figure_katagumi_friends.png",
-  },
-]
+import type { HelpCategoryType } from "@/features/help/types/helpCategory";
+import { getHelpCategory } from "@/features/help/api/getHelpCategory";
 
 export const HelpCategory = () => {
+  const [helpCategory, setHelpCategory] = useState<HelpCategoryType[]>([]);
+
+  useEffect(() => {
+    const fetchHelpCategory = async () => {
+      try {
+        const response = await getHelpCategory();
+        setHelpCategory(response);
+        console.log(response);
+      } catch (error) {
+        console.error("Error fetching helpCategory data:", error);
+      }
+    };
+
+    fetchHelpCategory();
+  }, []);
+
   return (
     <>
       <Header />
-      <div className = {Styles.wrapper}>
+      <div className={styles.wrapper}>
         <h1>ヘルプ一覧</h1>
-        
-        <div className = {Styles.helpCategoryContainer}>
-          {HelpDataDummy.map ((item) => (
+
+        <div className={styles.helpCategoryContainer}>
+          {helpCategory.map((item) => (
             <HelpCategoryCard
-              key = {item.id}
-              title = {item.title}
-              description = {item.description}
-              iconUrl = {item.iconUrl}
-              to = {``}
+              key={item.id}
+              title={item.categoryName}
+              description={item.description}
+              iconUrl={item.iconUrl}
+              to={``}
             />
           ))}
         </div>

--- a/frontend/src/app/routes/helpCategory.tsx
+++ b/frontend/src/app/routes/helpCategory.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import { HelpCategoryCard } from "@/features/help/components/helpCategory/helpCategoryCard";
-import styles from "@/features/help/styles/helpCategory.module.css";
 import { Header } from "@/components/ui/header/header";
-import type { HelpCategoryType } from "@/features/help/types/helpCategory";
+import { HelpCategoryCard } from "@/features/help/components/helpCategory/helpCategoryCard";
 import { getHelpCategory } from "@/features/help/api/getHelpCategory";
+import type { HelpCategoryType } from "@/features/help/types/helpCategory";
+import styles from "@/features/help/styles/helpCategory.module.css";
 
 export const HelpCategory = () => {
   const [helpCategory, setHelpCategory] = useState<HelpCategoryType[]>([]);
@@ -31,11 +31,11 @@ export const HelpCategory = () => {
         <div className={styles.helpCategoryContainer}>
           {helpCategory.map((item, index) => (
             <HelpCategoryCard
-              key={item.id ?? index}
+              key={item.categoryId ?? index}
               title={item.categoryName}
               description={item.description}
               iconUrl={item.iconUrl}
-              to={``}
+              to={`/help/${item.categoryId}`}
             />
           ))}
         </div>

--- a/frontend/src/app/routes/helpContents.tsx
+++ b/frontend/src/app/routes/helpContents.tsx
@@ -6,7 +6,6 @@ import { HelpContentsItem } from "@/features/help/components/helpContentsItem/he
 import { getHelpContents } from "@/features/help/api/getHelpContents";
 import { getHelpCategory } from "@/features/help/api/getHelpCategory";
 import { type HelpContentsType } from "@/features/help/types/helpContents";
-import { type HelpCategoryType } from "@/features/help/types/helpCategory";
 import style from "@/features/help/styles/helpContents.module.css";
 
 const HelpContents = () => {
@@ -17,39 +16,29 @@ const HelpContents = () => {
   const navigate = useNavigate();
 
   const [contents, setContents] = useState<HelpContentsType[]>([]);
-  const [category, setCategory] = useState<HelpCategoryType>({
-    categoryId: categoryId ?? null,
-    categoryName: state?.title ?? "",
-  });
+  const [categoryName, setCategoryName] = useState<string>(state?.title ?? "");
 
   useEffect(() => {
     const fetchHelpContents = async () => {
       try {
-        if (!params.id || isNaN(Number(params.id))) {
+        if (!categoryId || isNaN(Number(categoryId))) {
           navigate("/not-found", { replace: true });
           return;
         }
 
-        if (category.categoryId === null) {
-          throw new Error("categoryId is required");
-        }
-
-        if (category.categoryName === "") {
-          const categorys = await getHelpCategory();
-          const targetCategory = categorys.find(
-            (c) => c.categoryId === category.categoryId
+        if (!categoryName) {
+          const categories = await getHelpCategory();
+          const targetCategory = categories.find(
+            (c) => c.categoryId === categoryId
           );
           if (targetCategory) {
-            setCategory((prev) => ({
-              ...prev,
-              categoryName: targetCategory.categoryName,
-            }));
+            setCategoryName(targetCategory.categoryName);
           } else {
             throw new Error("categoryName is None");
           }
         }
 
-        const response = await getHelpContents(category.categoryId);
+        const response = await getHelpContents(categoryId);
         setContents(response);
         console.log(response);
       } catch (error) {
@@ -58,14 +47,15 @@ const HelpContents = () => {
     };
 
     fetchHelpContents();
-  }, [category, params.id, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [categoryId, navigate]);
 
   return (
     <div>
       <Header />
       <div className={style.helpContentsContainer}>
         <div className={style.titleContainer}>
-          <h1 className={style.categoryTitle}>{category.categoryName}</h1>
+          <h1 className={style.categoryTitle}>{categoryName}</h1>
           <GiControlTower className={style.categoryIcon} />
         </div>
 

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -6,12 +6,12 @@ export const paths = {
   },
   help: {
     category: {
-      path: "/help/category",
-      getHref: () => "/help/category",
+      path: "/help",
+      getHref: () => "/help",
     },
     contents: {
-      path: "/help/category/contents",
-      getHref: () => "/help/category/contents",
+      path: "/help/:id",
+      getHref: () => "/help/${id}",
     },
   },
   inquiry: {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -11,7 +11,7 @@ export const paths = {
     },
     contents: {
       path: "/help/:id",
-      getHref: () => "/help/${id}",
+      getHref: (id: number | string) => `/help/${id}`,
     },
   },
   inquiry: {

--- a/frontend/src/features/help/api/getHelpCategory.ts
+++ b/frontend/src/features/help/api/getHelpCategory.ts
@@ -1,0 +1,11 @@
+import { type HelpCategoryType } from "../types/helpCategory";
+
+export const getHelpCategory = async (): Promise<HelpCategoryType[]> => {
+  const response = await fetch(`http://localhost:8080/api/support/help/category`, {
+    method: "GET",
+  });
+
+  const result: HelpCategoryType[] = await response.json();
+
+  return result;
+};

--- a/frontend/src/features/help/api/getHelpCategory.ts
+++ b/frontend/src/features/help/api/getHelpCategory.ts
@@ -1,9 +1,12 @@
 import { type HelpCategoryType } from "../types/helpCategory";
 
 export const getHelpCategory = async (): Promise<HelpCategoryType[]> => {
-  const response = await fetch(`http://localhost:8080/api/support/help/category`, {
-    method: "GET",
-  });
+  const response = await fetch(
+    `http://localhost:8080/api/support/help/category`,
+    {
+      method: "GET",
+    }
+  );
 
   const result: HelpCategoryType[] = await response.json();
 

--- a/frontend/src/features/help/api/getHelpCategory.ts
+++ b/frontend/src/features/help/api/getHelpCategory.ts
@@ -2,7 +2,7 @@ import { type HelpCategoryType } from "../types/helpCategory";
 
 export const getHelpCategory = async (): Promise<HelpCategoryType[]> => {
   const response = await fetch(
-    `http://localhost:8080/api/support/help/category`,
+    `${import.meta.env.VITE_API_BASE_URL}/support/help/category`,
     {
       method: "GET",
     }

--- a/frontend/src/features/help/api/getHelpContents.ts
+++ b/frontend/src/features/help/api/getHelpContents.ts
@@ -1,0 +1,12 @@
+import { type HelpContentsType } from "../types/helpContents";
+
+export const getHelpContents = async (categoryId: number) => {
+  const response = await fetch(
+    `http://localhost:8080/api/support/help/category/${categoryId}`,
+    { method: "GET" }
+  );
+
+  const result: HelpContentsType[] = await response.json();
+
+  return result;
+};

--- a/frontend/src/features/help/api/getHelpContents.ts
+++ b/frontend/src/features/help/api/getHelpContents.ts
@@ -1,6 +1,8 @@
 import { type HelpContentsType } from "../types/helpContents";
 
-export const getHelpContents = async (categoryId: number) => {
+export const getHelpContents = async (
+  categoryId: number
+): Promise<HelpContentsType[]> => {
   const response = await fetch(
     `${import.meta.env.VITE_API_BASE_URL}/support/help/category/${categoryId}`,
     { method: "GET" }

--- a/frontend/src/features/help/api/getHelpContents.ts
+++ b/frontend/src/features/help/api/getHelpContents.ts
@@ -2,7 +2,7 @@ import { type HelpContentsType } from "../types/helpContents";
 
 export const getHelpContents = async (categoryId: number) => {
   const response = await fetch(
-    `http://localhost:8080/api/support/help/category/${categoryId}`,
+    `${import.meta.env.VITE_API_BASE_URL}/support/help/category/${categoryId}`,
     { method: "GET" }
   );
 

--- a/frontend/src/features/help/components/categoryBox.tsx
+++ b/frontend/src/features/help/components/categoryBox.tsx
@@ -1,8 +1,0 @@
-export const CategoryBox = () => {
-  return (
-    <div>
-      <h2>Category Title</h2>
-      <p>Category description goes here.</p>
-    </div>
-  );
-};

--- a/frontend/src/features/help/components/helpCategory/helpCategoryCard.tsx
+++ b/frontend/src/features/help/components/helpCategory/helpCategoryCard.tsx
@@ -1,7 +1,7 @@
 import styles from "./helpCategoryCard.module.css";
 import { Link } from "react-router";
 
-type HelpCategoryBoxProps = {
+type HelpCategoryCardProps = {
   title: string;
   description?: string;
   iconUrl?: string;
@@ -13,9 +13,9 @@ export const HelpCategoryCard = ({
   description,
   iconUrl,
   to,
-}: HelpCategoryBoxProps) => {
+}: HelpCategoryCardProps) => {
   return (
-    <Link to={to} className={styles.helpCategoryBox}>
+    <Link to={to} className={styles.helpCategoryBox} state={{ title: title }}>
       <div className={styles.contentInner}>
         {/*...タイトル...*/}
         <h3>{title}</h3>

--- a/frontend/src/features/help/styles/helpCategory.module.css
+++ b/frontend/src/features/help/styles/helpCategory.module.css
@@ -1,34 +1,35 @@
-.wrapper {
-    max-width: 1440px;
+.main {
+  display: flex;
+  width: 100%;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+}
 
-    margin-left: auto;
-    margin-right: auto;
-
-    min-height:100vh;
-
-    padding-left: 5%;
-    padding-right: 5%;
-}   
+.main > h1 {
+  width: 90%;
+  max-width: 1200px;
+  text-align: left;
+}
 
 .helpCategoryContainer {
-    display: grid;
-
-    grid-template-columns: repeat(3, 1fr);
-
-    gap: 1.5rem;
-
-    justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  justify-content: center;
+  width: 90%;
+  max-width: 1200px;
 }
 
 @media (max-width: 1024px) {
-    .helpCategoryContainer {
-        grid-template-columns: repeat(2, 1fr); 
-        gap: 4vw;
-    }
+  .helpCategoryContainer {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4vw;
+  }
 }
 
 @media (max-width: 600px) {
-    .helpCategoryContainer {
-        grid-template-columns: 1fr; 
-    }
+  .helpCategoryContainer {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/src/features/help/types/helpCategory.ts
+++ b/frontend/src/features/help/types/helpCategory.ts
@@ -1,0 +1,6 @@
+export type HelpCategoryType = {
+  id: number;
+  categoryName: string;
+  description?: string;
+  iconUrl?: string;
+};

--- a/frontend/src/features/help/types/helpCategory.ts
+++ b/frontend/src/features/help/types/helpCategory.ts
@@ -1,5 +1,5 @@
 export type HelpCategoryType = {
-  id: number;
+  categoryId: number | null;
   categoryName: string;
   description?: string;
   iconUrl?: string;

--- a/frontend/src/features/help/types/helpContents.ts
+++ b/frontend/src/features/help/types/helpContents.ts
@@ -1,4 +1,4 @@
-export type helpContentsData = {
+export type HelpContentsType = {
   contentsId: number;
   question: string;
   answer: string;


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
https://github.com/CERS-Projects/Tuna/issues/85

### イシュー番号(自動クローズ用)

close #85

## やったこと

<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？
- ヘルプカテゴリ取得のロジックを実装
- ヘルプコンテンツ取得のロジックを実装

## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
- なし

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
- ヘルプカテゴリ、コンテンツを閲覧できるようになる

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
- なし

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？
- 各機能においてデータ取得・表示ができた。
- コンテンツ画面でリロードした際（カテゴリ画面からの値渡し無しの場合）もヘルプコンテンツ取得ができた。

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」
- なし

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」
- なし

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- APIURLの取得は.envからやってます
