### PR TITLE
投稿検索画面のインポートパスとメニューバーとヘッダーが余計に表示されている問題を修正する

### DIFF
--- a/frontend/src/app/routes/app/searchPost.tsx
+++ b/frontend/src/app/routes/app/searchPost.tsx
@@ -1,10 +1,8 @@
-import { Header } from "@/components/ui/header/header";
 import { InfoBox } from "@/components/ui/infoBox/infoBox";
 import {
   SearchFilter,
   type NodeItem,
 } from "@/features/search/components/searchFilter";
-import { Menu } from "@/features/timeline/components/menu/menu";
 import styles from "@/features/search/styles/searchPost.module.css";
 import { useRef } from "react";
 import { Modal, type ModalHandle } from "@/components/ui/modal/modal";
@@ -33,12 +31,8 @@ const SearchPost = () => {
   };
   return (
     <div className={styles.searchPostLayout}>
-      <Header />
       <div className={styles.searchPostContainer}>
-        <div className={styles.searchPostAreaLeft}>
-          <Menu />
-        </div>
-        <div className={styles.searchPostAreaCenter}>
+        <div className={styles.searchPostMain}>
           <button onClick={modalButtonClick} className={styles.modalButton}>
             <RiCompass3Line />
           </button>
@@ -46,7 +40,7 @@ const SearchPost = () => {
             <SearchHistory />
           </div>
         </div>
-        <div className={styles.searchPostAreaRight}>
+        <div className={styles.searchPostSub}>
           <InfoBox>
             <SearchFilter flatData={exampleFlatData} />
           </InfoBox>

--- a/frontend/src/features/search/styles/searchPost.module.css
+++ b/frontend/src/features/search/styles/searchPost.module.css
@@ -16,19 +16,14 @@
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: 6% 1fr 40%;
+  grid-template-columns: 1fr 40%;
 }
 
-.searchPostAreaLeft {
-  border-right: 1px solid rgb(50, 85, 150);
-  z-index: 70;
-}
-
-.searchPostAreaCenter {
+.searchPostMain {
   overflow-y: auto;
 }
 
-.searchPostAreaRight {
+.searchPostSub {
   border-left: 1px solid rgb(50, 85, 150);
   overflow: auto;
   min-height: 100%;
@@ -45,22 +40,13 @@
     display: flex;
     flex-direction: column;
   }
-  .searchPostAreaCenter {
+  .searchPostMain {
     flex: 1;
     order: 1;
     width: 100%;
     height: auto;
   }
-  .searchPostAreaLeft {
-    order: 2;
-    width: 100%;
-    height: 60px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-    align-items: center;
-  }
-  .searchPostAreaRight {
+  .searchPostSub {
     display: none;
   }
   .modalButton {


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

feature/ #121

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### feature/ #121 

### イシュー番号(自動クローズ用)

close #121 

## やったこと

<!-- このPRで何をしたのか？ -->

searchPost.tsxで起きていたインポートエラーの修正（不必要なコンポーネントをすべて削除）
searchPost.module.cssをレイアウトに合わせた形に修正。画面をメニューバー用に3分割していたのを2分割にしてclassnameを修正しました。基本はtimeline.module.cssに準拠してます。

## やらないこと

<!-- このPRでやらないことは何か？ -->

特にないです

## できるようになること（ユーザ目線）

エラーが解消されたので画面が想定通り使用できるようになります。

## できなくなること（ユーザ目線）

とくにないです

## 動作確認

エラーが出ないかと画面に不必要なコンポーネントが含まれていないか確認しました。

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
