### PR TITLE
授業資料一覧画面の実装: frontend 

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -99,11 +99,11 @@ const createAppRouter = (queryClient: QueryClient) => {
           () => import("./routes/app/searchPost"),
         ),
         route(
-          paths.app.Classroom.path,
+          paths.app.classroom.path,
           () => import("./routes/app/searchClassroom"),
         ),
         route(
-          paths.app.Classroom.contents.path,
+          paths.app.classroom.contents.path,
           () => import("./routes/app/classroom/material"),
         ),
       ],

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -95,6 +95,10 @@ const createAppRouter = (queryClient: QueryClient) => {
           () => import("./routes/app/detailPost"),
         ),
         route(
+          paths.app.material.path,
+          () => import("./routes/app/classroom/material"),
+        ),
+        route(
           paths.app.searchPost.path,
           () => import("./routes/app/searchPost"),
         ),
@@ -126,24 +130,24 @@ const createAppRouter = (queryClient: QueryClient) => {
           children: [
             route(
               paths.app.management.group.root.path,
-              () => import("./routes/app/management/group/groupList")
+              () => import("./routes/app/management/group/groupList"),
             ),
             route(
               paths.app.management.group.new.path,
-              () => import("./routes/app/management/group/groupNew")
+              () => import("./routes/app/management/group/groupNew"),
             ),
             route(
               paths.app.management.group.edit.path,
-              () => import("./routes/app/management/group/groupEdit")
+              () => import("./routes/app/management/group/groupEdit"),
             ),
           ],
         },
         {
           path: paths.app.management.account.root.path,
           lazy: () =>
-            import(
-              "../features/management/layouts/accountShell/accountShell"
-            ).then(convert(queryClient)),
+            import("../features/management/layouts/accountShell/accountShell").then(
+              convert(queryClient),
+            ),
           children: [
             {
               index: true,
@@ -153,23 +157,23 @@ const createAppRouter = (queryClient: QueryClient) => {
             },
             route(
               paths.app.management.account.list.path,
-              () => import("./routes/app/management/account/accountList")
+              () => import("./routes/app/management/account/accountList"),
             ),
             route(
               paths.app.management.account.edit.path,
-              () => import("./routes/app/management/account/accountEdit")
+              () => import("./routes/app/management/account/accountEdit"),
             ),
             route(
               paths.app.management.account.new.path,
-              () => import("./routes/app/management/account/accountNew")
+              () => import("./routes/app/management/account/accountNew"),
             ),
             route(
               paths.app.management.account.register.path,
-              () => import("./routes/app/management/account/accountRegister")
+              () => import("./routes/app/management/account/accountRegister"),
             ),
             route(
               paths.app.management.account.import.path,
-              () => import("./routes/app/management/account/accountImport")
+              () => import("./routes/app/management/account/accountImport"),
             ),
           ],
         },

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -95,16 +95,16 @@ const createAppRouter = (queryClient: QueryClient) => {
           () => import("./routes/app/detailPost"),
         ),
         route(
-          paths.app.material.path,
-          () => import("./routes/app/classroom/material"),
-        ),
-        route(
           paths.app.searchPost.path,
           () => import("./routes/app/searchPost"),
         ),
         route(
-          paths.app.searchClassroom.path,
-          () => import("./routes/app/searchClassroom")
+          paths.app.Classroom.path,
+          () => import("./routes/app/searchClassroom"),
+        ),
+        route(
+          paths.app.Classroom.contents.path,
+          () => import("./routes/app/classroom/material"),
         ),
       ],
     },

--- a/frontend/src/app/routes/app/classroom/material.tsx
+++ b/frontend/src/app/routes/app/classroom/material.tsx
@@ -49,7 +49,7 @@ const sampleItems = [
   },
 ];
 
-const Timeline = () => {
+const Material = () => {
   const modalRef = useRef<ModalHandle>(null);
   const modalButtonClick = () => {
     if (modalRef.current) {
@@ -62,7 +62,7 @@ const Timeline = () => {
         <div className={styles.materialMain}>
           <div className={styles.feedWrapper}>
             <button onClick={modalButtonClick} className={styles.modalButton}>
-              <div className={styles.modalIcon}>
+              <div>
                 <RiCompass3Line />
               </div>
             </button>
@@ -96,4 +96,4 @@ const Timeline = () => {
   );
 };
 
-export default Timeline;
+export default Material;

--- a/frontend/src/app/routes/app/classroom/material.tsx
+++ b/frontend/src/app/routes/app/classroom/material.tsx
@@ -5,10 +5,11 @@ import { useRef } from "react";
 import { RiCompass3Line } from "react-icons/ri";
 import { InfoBox } from "@/components/ui/infoBox/infoBox";
 import styles from "@/features/classroom/material/styles/material.module.css";
+import { useLocation } from "react-router";
 
-const dummyClass = {
-  name: "C言語",
-  information: "C言語の授業ルームですわ～～～～～～",
+type ClassData = {
+  name: string;
+  description: string;
 };
 
 // 1. カテゴリー（親）のデータ
@@ -56,6 +57,15 @@ const Material = () => {
       modalRef.current.show();
     }
   };
+
+  const location = useLocation();
+  const state = location.state as ClassData | null;
+
+  const classData = state || {
+    name: "エラー",
+    description: "データが見つかりませんでした。再度選択してください。",
+  };
+
   return (
     <div className={styles.materialLayout}>
       <div className={styles.materialContainer}>
@@ -67,8 +77,8 @@ const Material = () => {
               </div>
             </button>
             <div className={styles.headerArea}>
-              <h1>{dummyClass.name}</h1>
-              <p>{dummyClass.information}</p>
+              <h1>{classData.name}</h1>
+              <p>{classData.description}</p>
             </div>
             <hr className={styles.divider} />
             <div className={styles.cardList}>

--- a/frontend/src/app/routes/app/classroom/material.tsx
+++ b/frontend/src/app/routes/app/classroom/material.tsx
@@ -57,9 +57,9 @@ const Timeline = () => {
     }
   };
   return (
-    <div className={styles.timelineLayout}>
-      <div className={styles.timelineContainer}>
-        <div className={styles.timelineMain}>
+    <div className={styles.materialLayout}>
+      <div className={styles.materialContainer}>
+        <div className={styles.materialMain}>
           <div className={styles.feedWrapper}>
             <button onClick={modalButtonClick} className={styles.modalButton}>
               <div className={styles.modalIcon}>
@@ -78,7 +78,7 @@ const Timeline = () => {
             </div>
           </div>
         </div>
-        <div className={styles.timelineSub}>
+        <div className={styles.materialSub}>
           <InfoBox>
             <MaterialCategory
               categories={sampleCategories}

--- a/frontend/src/app/routes/app/classroom/material.tsx
+++ b/frontend/src/app/routes/app/classroom/material.tsx
@@ -1,0 +1,99 @@
+import { MaterialCard } from "@/features/classroom/material/components/materialCard";
+import { MaterialCategory } from "@/features/classroom/material/components/materialCategory";
+import { Modal, type ModalHandle } from "@/components/ui/modal/modal";
+import { useRef } from "react";
+import { RiCompass3Line } from "react-icons/ri";
+import { InfoBox } from "@/components/ui/infoBox/infoBox";
+import styles from "@/features/classroom/material/styles/material.module.css";
+
+const dummyClass = {
+  name: "C言語",
+  information: "C言語の授業ルームですわ～～～～～～",
+};
+
+// 1. カテゴリー（親）のデータ
+const sampleCategories = [
+  { id: 1, name: "課題資料", createdAt: "2025/07/03" },
+  { id: 2, name: "授業資料", createdAt: "2025/07/03" },
+  { id: 3, name: "期末試験", createdAt: "2025/07/03" },
+];
+
+// 2. PDFファイル（子）のデータ
+const sampleItems = [
+  // カテゴリーID: 1 (課題資料) に紐づくデータ
+  {
+    categoryId: 1,
+    title: "a",
+    fileName: "0701課題資料.pdf",
+    createdAt: "2025/07/01",
+    fileUrl: "/files/kadai1.pdf",
+    materialId: 1,
+  },
+  {
+    categoryId: 1,
+    title: "a",
+    fileName: "0703課題資料.pdf",
+    createdAt: "2025/07/03",
+    fileUrl: "/files/kadai2.pdf",
+    materialId: 2,
+  },
+
+  // カテゴリーID: 2 (授業資料) に紐づくデータ
+  {
+    categoryId: 2,
+    title: "a",
+    fileName: "0701授業資料.pdf",
+    createdAt: "2025/07/01",
+    fileUrl: "/files/lesson1.pdf",
+    materialId: 3,
+  },
+];
+
+const Timeline = () => {
+  const modalRef = useRef<ModalHandle>(null);
+  const modalButtonClick = () => {
+    if (modalRef.current) {
+      modalRef.current.show();
+    }
+  };
+  return (
+    <div className={styles.timelineLayout}>
+      <div className={styles.timelineContainer}>
+        <div className={styles.timelineMain}>
+          <div className={styles.feedWrapper}>
+            <button onClick={modalButtonClick} className={styles.modalButton}>
+              <div className={styles.modalIcon}>
+                <RiCompass3Line />
+              </div>
+            </button>
+            <div className={styles.headerArea}>
+              <h1>{dummyClass.name}</h1>
+              <p>{dummyClass.information}</p>
+            </div>
+            <hr className={styles.divider} />
+            <div className={styles.cardList}>
+              {sampleItems.map((item) => (
+                <MaterialCard key={item.materialId} item={item} />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className={styles.timelineSub}>
+          <InfoBox>
+            <MaterialCategory
+              categories={sampleCategories}
+              items={sampleItems}
+            />
+          </InfoBox>
+        </div>
+      </div>
+      <Modal ref={modalRef} height={"fit-content"} width={"fit-content"}>
+        <InfoBox>
+          <MaterialCategory categories={sampleCategories} items={sampleItems} />
+        </InfoBox>
+      </Modal>
+    </div>
+  );
+};
+
+export default Timeline;

--- a/frontend/src/app/routes/app/classroom/material.tsx
+++ b/frontend/src/app/routes/app/classroom/material.tsx
@@ -5,11 +5,10 @@ import { useRef } from "react";
 import { RiCompass3Line } from "react-icons/ri";
 import { InfoBox } from "@/components/ui/infoBox/infoBox";
 import styles from "@/features/classroom/material/styles/material.module.css";
-import { useLocation } from "react-router";
 
-type ClassData = {
-  name: string;
-  description: string;
+const ClassData = {
+  name: "c",
+  description: "サカバンバスピス",
 };
 
 // 1. カテゴリー（親）のデータ
@@ -18,7 +17,6 @@ const sampleCategories = [
   { id: 2, name: "授業資料", createdAt: "2025/07/03" },
   { id: 3, name: "期末試験", createdAt: "2025/07/03" },
 ];
-
 // 2. PDFファイル（子）のデータ
 const sampleItems = [
   // カテゴリーID: 1 (課題資料) に紐づくデータ
@@ -58,14 +56,6 @@ const Material = () => {
     }
   };
 
-  const location = useLocation();
-  const state = location.state as ClassData | null;
-
-  const classData = state || {
-    name: "エラー",
-    description: "データが見つかりませんでした。再度選択してください。",
-  };
-
   return (
     <div className={styles.materialLayout}>
       <div className={styles.materialContainer}>
@@ -77,8 +67,8 @@ const Material = () => {
               </div>
             </button>
             <div className={styles.headerArea}>
-              <h1>{classData.name}</h1>
-              <p>{classData.description}</p>
+              <h1>{ClassData.name}</h1>
+              <p>{ClassData.description}</p>
             </div>
             <hr className={styles.divider} />
             <div className={styles.cardList}>

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -102,6 +102,10 @@ export const paths = {
       path: "/app/test",
       getHref: () => "/app/test",
     },
+    material: {
+      path: "/app/classroom/material",
+      getHref: () => "/app/classroom/material",
+    },
 
     // 教師ルート
     management: {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -90,12 +90,12 @@ export const paths = {
       path: "/app/search",
       getHref: () => "/app/search",
     },
-    Classroom: {
-      path: "/app/Classroom",
-      getHref: () => "/app/Classroom",
+    classroom: {
+      path: "/app/classroom",
+      getHref: () => "/app/classroom",
       contents: {
-        path: "Classroom/:id",
-        getHref: (id: number) => `/app/Classroom/${id}`,
+        path: "/app/classroom/:id",
+        getHref: (id: number) => `/app/classroom/${id}`,
       },
     },
     test: {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -83,28 +83,24 @@ export const paths = {
       getHref: () => "/app/timeline",
       detail: {
         path: "/app/timeline/:id",
-        getHref: (id: number | string) => `/app/timeline/${id}`,
+        getHref: (id: number) => `/app/timeline/${id}`,
       },
     },
     searchPost: {
       path: "/app/search",
       getHref: () => "/app/search",
     },
-    searchClassroom: {
-      path: "/app/searchClassroom",
-      getHref: () => "/app/searchClassroom",
+    Classroom: {
+      path: "/app/Classroom",
+      getHref: () => "/app/Classroom",
       contents: {
-        path: "/searchClassroom/:id",
-        getHref: (id: number | string) => `/app/searchClassroom/${id}`,
+        path: "Classroom/:id",
+        getHref: (id: number) => `/app/Classroom/${id}`,
       },
     },
     test: {
       path: "/app/test",
       getHref: () => "/app/test",
-    },
-    material: {
-      path: "/app/classroom/material",
-      getHref: () => "/app/classroom/material",
     },
 
     // 教師ルート

--- a/frontend/src/features/classroom/material/components/materialCard.module.css
+++ b/frontend/src/features/classroom/material/components/materialCard.module.css
@@ -1,0 +1,90 @@
+.materialCard {
+  border: 2px solid rgb(50, 85, 150);
+  border-radius: 12px;
+  background-color: #fff;
+  transition: all 0.2s ease;
+  overflow: hidden;
+  margin: 10px 0;
+  width: 100%;
+}
+
+.materialCard:hover {
+  box-shadow: 0 4px 12px rgba(50, 85, 150, 0.2);
+  transform: translateY(-2px);
+  cursor: pointer;
+}
+
+.materialCard a {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  padding: 16px;
+}
+
+.materialContent {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.titleArea h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #333;
+  line-height: 1.4;
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 4px 0;
+  width: 90%;
+}
+
+.fileMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.fileName {
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pdfIcon {
+  color: rgb(50, 85, 150);
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+
+.downloadIcon {
+  color: #999;
+  font-size: 1.4rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+@media screen and (max-width: 960px) {
+  .materialCard {
+    max-width: 80%;
+  }
+  .materialCard a {
+    padding: 12px;
+  }
+  .titleArea h3 {
+    font-size: 0.95rem;
+  }
+
+  .fileMeta {
+    font-size: 0.85rem;
+  }
+  .pdfIcon,
+  .downloadIcon {
+    font-size: 1.25rem;
+  }
+}

--- a/frontend/src/features/classroom/material/components/materialCard.tsx
+++ b/frontend/src/features/classroom/material/components/materialCard.tsx
@@ -1,0 +1,27 @@
+import styles from "./materialCard.module.css";
+import { type MaterialType } from "../types/material";
+import { MdOutlinePictureAsPdf, MdFileDownload } from "react-icons/md";
+
+type materialProps = {
+  item: MaterialType;
+};
+
+export const MaterialCard = ({ item }: materialProps) => {
+  return (
+    <div className={styles.materialCard}>
+      <a href={item.fileUrl} download={item.fileName}>
+        <div className={styles.materialContent}>
+          <div className={styles.titleArea}>
+            <h3>{item.title}</h3>
+          </div>
+          <hr className={styles.divider} />
+          <div className={styles.fileMeta}>
+            <MdOutlinePictureAsPdf className={styles.pdfIcon} />
+            <span className={styles.fileName}>{item.fileName}</span>
+            <MdFileDownload className={styles.downloadIcon} />
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+};

--- a/frontend/src/features/classroom/material/components/materialCard.tsx
+++ b/frontend/src/features/classroom/material/components/materialCard.tsx
@@ -2,11 +2,11 @@ import styles from "./materialCard.module.css";
 import { type MaterialType } from "../types/material";
 import { MdOutlinePictureAsPdf, MdFileDownload } from "react-icons/md";
 
-type materialProps = {
-  item: MaterialType;
+type MaterialProps = {
+  item: materialType;
 };
 
-export const MaterialCard = ({ item }: materialProps) => {
+export const MaterialCard = ({ item }: MaterialProps) => {
   return (
     <div className={styles.materialCard}>
       <a href={item.fileUrl} download={item.fileName}>

--- a/frontend/src/features/classroom/material/components/materialCard.tsx
+++ b/frontend/src/features/classroom/material/components/materialCard.tsx
@@ -1,5 +1,5 @@
 import styles from "./materialCard.module.css";
-import { type MaterialType } from "../types/material";
+import { type materialType } from "../types/material";
 import { MdOutlinePictureAsPdf, MdFileDownload } from "react-icons/md";
 
 type MaterialProps = {
@@ -8,7 +8,7 @@ type MaterialProps = {
 
 export const MaterialCard = ({ item }: MaterialProps) => {
   return (
-    <div className={styles.materialCard}>
+    <div className={styles.materialCard}> 
       <a href={item.fileUrl} download={item.fileName}>
         <div className={styles.materialContent}>
           <div className={styles.titleArea}>

--- a/frontend/src/features/classroom/material/components/materialCategory.module.css
+++ b/frontend/src/features/classroom/material/components/materialCategory.module.css
@@ -1,0 +1,146 @@
+.container {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  font-family: sans-serif;
+}
+
+.section {
+  margin-bottom: 8px;
+  border: 1px solid transparent;
+}
+
+.header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background-color: #ffffff;
+  border: 1px solid rgb(50, 85, 150);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  gap: 8px;
+}
+
+.header:hover {
+  background-color: #f1f5f9;
+}
+
+.headerActive {
+  background-color: #f1f5f9;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.arrow {
+  font-size: 1.5rem;
+  color: rgb(50, 85, 150);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.arrowOpen {
+  transform: rotate(90deg);
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: bold;
+  flex: 1;
+  text-align: left;
+}
+
+.count {
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.gridWrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border-left: 1px solid rgb(50, 85, 150);
+  border-right: 1px solid rgb(50, 85, 150);
+  border-bottom: 0px solid rgb(50, 85, 150);
+  background-color: #ffffff;
+}
+
+.gridWrapperOpen {
+  grid-template-rows: 1fr;
+  border-bottom-width: 1px;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+.overflowInner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.contentList {
+  padding: 8px 0;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.gridWrapperOpen .contentList {
+  opacity: 1;
+}
+
+.pdfLink {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px 10px 40px;
+  text-decoration: none;
+  color: #333;
+  transition: background-color 0.2s;
+}
+
+.pdfLink:hover {
+  background-color: #f1f5f9;
+}
+
+.pdfMain {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pdfIcon {
+  color: rgb(50, 85, 150);
+  font-size: 1.2rem;
+}
+
+.fileName {
+  font-size: 0.95rem;
+  color: rgb(50, 85, 150);
+  text-decoration: underline;
+}
+
+.pdfSub {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.date {
+  font-size: 0.8rem;
+  color: #777;
+}
+
+.downloadIcon {
+  color: #999;
+  font-size: 1.1rem;
+}
+
+.pdfLink:hover .downloadIcon {
+  color: rgb(50, 85, 150);
+}
+
+.noData {
+  padding: 16px;
+  text-align: center;
+  color: #999;
+  font-size: 0.9rem;
+}

--- a/frontend/src/features/classroom/material/components/materialCategory.tsx
+++ b/frontend/src/features/classroom/material/components/materialCategory.tsx
@@ -1,0 +1,86 @@
+import { useState, useMemo } from "react";
+import styles from "./materialCategory.module.css";
+import {
+  MdKeyboardArrowRight,
+  MdOutlinePictureAsPdf,
+  MdFileDownload,
+} from "react-icons/md";
+
+import { type MaterialType, type CategoryType } from "../types/material";
+
+type materialProps = {
+  categories: CategoryType[];
+  items: MaterialType[];
+};
+
+export const MaterialCategory = ({ categories, items }: materialProps) => {
+  const [openIds, setOpenIds] = useState<number[]>([]);
+
+  const groupedData = useMemo(() => {
+    return categories.map((cat) => ({
+      ...cat,
+      children: items.filter((item) => item.categoryId === cat.id),
+    }));
+  }, [categories, items]);
+
+  const toggleCategory = (id: number) => {
+    setOpenIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((openId) => openId !== id)
+        : [...prev, id],
+    );
+  };
+
+  return (
+    <div className={styles.container}>
+      {groupedData.map((category) => {
+        const isOpen = openIds.includes(category.id);
+        return (
+          <div key={category.id} className={styles.section}>
+            <button
+              className={`${styles.header} ${isOpen ? styles.headerActive : ""}`}
+              onClick={() => toggleCategory(category.id)}
+              aria-expanded={isOpen}
+            >
+              <MdKeyboardArrowRight
+                className={`${styles.arrow} ${isOpen ? styles.arrowOpen : ""}`}
+              />
+              <span className={styles.title}>{category.name}</span>
+            </button>
+            <div
+              className={`${styles.gridWrapper} ${isOpen ? styles.gridWrapperOpen : ""}`}
+              aria-hidden={!isOpen}
+            >
+              <div className={styles.overflowInner}>
+                <div className={styles.contentList}>
+                  {category.children.map((item, index) => (
+                    <a
+                      key={index}
+                      href={item.fileUrl}
+                      download={item.fileName}
+                      className={styles.pdfLink}
+                    >
+                      <div className={styles.pdfMain}>
+                        <MdOutlinePictureAsPdf className={styles.pdfIcon} />
+                        <span className={styles.fileName}>{item.fileName}</span>
+                      </div>
+                      <div className={styles.pdfSub}>
+                        <span className={styles.date}>{item.createdAt}</span>
+                        <MdFileDownload className={styles.downloadIcon} />
+                      </div>
+                    </a>
+                  ))}
+                  {category.children.length === 0 && (
+                    <p className={styles.noData}>
+                      公開されている資料はありません
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/features/classroom/material/components/materialCategory.tsx
+++ b/frontend/src/features/classroom/material/components/materialCategory.tsx
@@ -8,12 +8,12 @@ import {
 
 import { type MaterialType, type CategoryType } from "../types/material";
 
-type materialProps = {
-  categories: CategoryType[];
-  items: MaterialType[];
+type MaterialProps = {
+  categories: categoryType[];
+  items: materialType[];
 };
 
-export const MaterialCategory = ({ categories, items }: materialProps) => {
+export const MaterialCategory = ({ categories, items }: MaterialProps) => {
   const [openIds, setOpenIds] = useState<number[]>([]);
 
   const groupedData = useMemo(() => {
@@ -53,9 +53,9 @@ export const MaterialCategory = ({ categories, items }: materialProps) => {
             >
               <div className={styles.overflowInner}>
                 <div className={styles.contentList}>
-                  {category.children.map((item, index) => (
+                  {category.children.map((item) => (
                     <a
-                      key={index}
+                      key={item.materialId}
                       href={item.fileUrl}
                       download={item.fileName}
                       className={styles.pdfLink}

--- a/frontend/src/features/classroom/material/components/materialCategory.tsx
+++ b/frontend/src/features/classroom/material/components/materialCategory.tsx
@@ -6,7 +6,7 @@ import {
   MdFileDownload,
 } from "react-icons/md";
 
-import { type MaterialType, type CategoryType } from "../types/material";
+import { type materialType, type categoryType } from "../types/material";
 
 type MaterialProps = {
   categories: categoryType[];

--- a/frontend/src/features/classroom/material/styles/material.module.css
+++ b/frontend/src/features/classroom/material/styles/material.module.css
@@ -1,0 +1,100 @@
+.timelineLayout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background-color: #f5f8fa;
+}
+
+.timelineContainer {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 40%;
+}
+
+.timelineMain {
+  overflow-y: auto;
+  padding-top: 24px;
+}
+
+.feedWrapper {
+  width: 90%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.headerArea {
+  margin-bottom: 16px;
+  padding: 0 8px;
+}
+
+.headerArea h1 {
+  font-size: 1.8rem;
+  margin: 0 0 8px 0;
+  color: #333;
+}
+
+.headerArea p {
+  color: #666;
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid #e1e8ed;
+  margin: 20px 0;
+  width: 100%;
+}
+
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+/* --- サブエリア（右側） --- */
+.timelineSub {
+  border-left: 1px solid #e1e8ed; /* 色を薄くして上品に */
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.modalButton {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  .timelineContainer {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .timelineMain {
+    padding: 16px;
+  }
+
+  .feedWrapper {
+    max-width: 100%;
+  }
+
+  .timelineSub {
+    display: none;
+  }
+  .modalButton {
+    position: fixed;
+    display: block;
+    font-size: 3rem;
+    z-index: 100;
+    background: none;
+    border: none;
+    right: 3%;
+    color: rgb(50, 85, 150);
+  }
+  .modalButton:hover {
+    color: #007bff;
+  }
+}

--- a/frontend/src/features/classroom/material/styles/material.module.css
+++ b/frontend/src/features/classroom/material/styles/material.module.css
@@ -1,4 +1,4 @@
-.timelineLayout {
+.materialLayout {
   display: flex;
   flex-direction: column;
   height: 100vh;
@@ -6,14 +6,14 @@
   background-color: #f5f8fa;
 }
 
-.timelineContainer {
+.materialContainer {
   flex: 1;
   min-height: 0;
   display: grid;
   grid-template-columns: 1fr 40%;
 }
 
-.timelineMain {
+.materialMain {
   overflow-y: auto;
   padding-top: 24px;
 }
@@ -56,9 +56,8 @@
   align-items: center;
 }
 
-/* --- サブエリア（右側） --- */
-.timelineSub {
-  border-left: 1px solid #e1e8ed; /* 色を薄くして上品に */
+.materialSub {
+  border-left: 1px solid #e1e8ed;
   overflow-y: auto;
   padding: 24px;
 }
@@ -68,12 +67,12 @@
 }
 
 @media (max-width: 960px) {
-  .timelineContainer {
+  .materialContainer {
     display: flex;
     flex-direction: column;
   }
 
-  .timelineMain {
+  .materialMain {
     padding: 16px;
   }
 
@@ -81,7 +80,7 @@
     max-width: 100%;
   }
 
-  .timelineSub {
+  .materialSub {
     display: none;
   }
   .modalButton {

--- a/frontend/src/features/classroom/material/types/material.ts
+++ b/frontend/src/features/classroom/material/types/material.ts
@@ -1,0 +1,19 @@
+export type categoryType = {
+  id: number;
+  name: string;
+  createdAt: string;
+};
+
+export type materialType = {
+  categoryId: number;
+  materialId: number;
+  title: string;
+  fileName: string;
+  fileUrl: string;
+  createdAt: string;
+};
+
+export type classroomData = {
+  className: string;
+  information: string;
+};

--- a/frontend/src/features/searchClassroom/components/selectClassroom.tsx
+++ b/frontend/src/features/searchClassroom/components/selectClassroom.tsx
@@ -11,7 +11,11 @@ export const SelectClassroom = ({
 }: Classroom) => {
   return (
     <Link
-      to={`${roomId}`}
+      to={`/app/Classroom/${roomId}`}
+      state={{
+        name: roomName,
+        description: description,
+      }}
       relative="path"
       className={styles.selectClassroomBox}
     >

--- a/frontend/src/features/searchClassroom/components/selectClassroom.tsx
+++ b/frontend/src/features/searchClassroom/components/selectClassroom.tsx
@@ -1,6 +1,7 @@
 import styles from "./selectClassroom.module.css";
 import { Link } from "react-router";
 import type { Classroom } from "@/features/searchClassroom/types/SelectClassroom";
+import { paths } from "@/config/paths";
 
 export const SelectClassroom = ({
   roomId,
@@ -11,11 +12,7 @@ export const SelectClassroom = ({
 }: Classroom) => {
   return (
     <Link
-      to={`/app/Classroom/${roomId}`}
-      state={{
-        name: roomName,
-        description: description,
-      }}
+      to={paths.app.classroom.contents.getHref(roomId)}
       relative="path"
       className={styles.selectClassroomBox}
     >


### PR DESCRIPTION
feature/#134

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## ＃134

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク

### イシュー番号(自動クローズ用)

close #134 

## やったこと

<!-- このPRで何をしたのか？ -->

授業資料一覧画面の実装
画面実装に必要なコンポーネントの作成
必要なpathの作成

## やらないこと

<!-- このPRでやらないことは何か？ -->

ロジック部分は作成していないため現時点ではダミーデータ使用。

## できるようになること（ユーザ目線）

授業資料の閲覧とダウンロード

## できなくなること（ユーザ目線）

特になし

## 動作確認

実装後画面の動作確認済み

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

無し

## テスト

<!-- テスト方法や結果 -->

コンポーネント押下で折り畳みが動くこと、ダウンロードできること実証済み

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

とくにないです
