### PR TITLE
手入力アカウント登録画面を実装する: frontend

### DIFF
--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -1,14 +1,47 @@
 import { BackPage } from "@/features/management/components/backPage/backPage";
+import {
+  StudentAccountRegisterForm,
+  TeacherAccountRegisterForm,
+} from "@/features/management/components/accountRegisterForm/accountRegisterForm";
+import { useState } from "react";
 import { paths } from "@/config/paths";
+import styles from "@/features/management/style/accountRegister.module.css";
 
 const AccountRegister = () => {
+  const [activeTab, setActiveTab] = useState<"student" | "teacher">("student");
+
   return (
-    <div>
+    <div className={styles.contents}>
       <BackPage
         to={paths.app.management.account.new.path}
         label="アカウント登録メニューに戻る"
       />
-      account register
+      <header className={styles.header}>
+        <h3 className={styles.sectionName}>手入力アカウント登録</h3>
+
+        <div className={styles.toggleTab} data-active={activeTab}>
+          <button
+            className={activeTab === "student" ? styles.tabActive : ""}
+            onClick={() => setActiveTab("student")}
+          >
+            生徒
+          </button>
+          <button
+            className={activeTab === "teacher" ? styles.tabActive : ""}
+            onClick={() => setActiveTab("teacher")}
+          >
+            教師
+          </button>
+        </div>
+      </header>
+
+      <hr />
+
+      {activeTab === "student" ? (
+        <StudentAccountRegisterForm />
+      ) : (
+        <TeacherAccountRegisterForm />
+      )}
     </div>
   );
 };

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -7,20 +7,111 @@ import {
   type StudentAccountRegisterType,
   type TeacherAccountRegisterType,
 } from "@/features/management/types/account";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { paths } from "@/config/paths";
 import styles from "@/features/management/style/accountRegister.module.css";
-import { StudentAccountRegisterTable } from "@/features/management/components/accountRegisterTable/accountRegisterTable";
+import {
+  StudentAccountRegisterTable,
+  TeacherAccountRegisterTable,
+} from "@/features/management/components/accountRegisterTable/accountRegisterTable";
+
+const initialStudent: StudentAccountRegisterType = {
+  name: "",
+  grade: 1,
+  email: "",
+  password: "",
+  passwordConfirm: "",
+  entryDate: "",
+  graduateDate: "",
+};
+
+const initialTeacher: TeacherAccountRegisterType = {
+  name: "",
+  email: "",
+  password: "",
+  passwordConfirm: "",
+};
 
 const AccountRegister = () => {
   const [activeTab, setActiveTab] = useState<"student" | "teacher">("student");
+  const formRef = useRef<HTMLDivElement | null>(null);
+  const scrollToForm = () => {
+    formRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  };
+
+  const studentTableRef = useRef<(HTMLTableRowElement | null)[]>([]);
+  const scrollToStudentTable = (index: number | null) => {
+    if (index !== null) {
+      studentTableRef.current[index]?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  const teacherTableRef = useRef<(HTMLTableRowElement | null)[]>([]);
+  const scrollToTeacherTable = (index: number | null) => {
+    if (index !== null) {
+      teacherTableRef.current[index]?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  const [currentStudent, setCurrentStudent] =
+    useState<StudentAccountRegisterType>(initialStudent);
+
+  const [currentTeacher, setCurrentTeacher] =
+    useState<TeacherAccountRegisterType>({
+      name: "",
+      email: "",
+      password: "",
+      passwordConfirm: "",
+    });
 
   const [studentAccounts, setStudentAccounts] = useState<
     StudentAccountRegisterType[]
   >([]);
+
+  const [editingStudentIndex, setEditingStudentIndex] = useState<number | null>(
+    null,
+  );
+
   const [teacherAccounts, setTeacherAccounts] = useState<
     TeacherAccountRegisterType[]
   >([]);
+
+  const [editingTeacherIndex, setEditingTeacherIndex] = useState<number | null>(
+    null,
+  );
+
+  const handleSubmit = () => {
+    const cancel = confirm("この内容で登録しますか？");
+
+    if (cancel === false) return;
+
+    if (activeTab === "student") {
+      if (studentAccounts.length === 0) {
+        alert("データが追加されていません");
+        return;
+      }
+
+      console.log(studentAccounts);
+      setStudentAccounts([]);
+    } else {
+      if (teacherAccounts.length === 0) {
+        alert("データが追加されていません");
+        return;
+      }
+
+      console.log(teacherAccounts);
+      setTeacherAccounts([]);
+    }
+  };
 
   return (
     <div className={styles.contentsContainer}>
@@ -50,16 +141,28 @@ const AccountRegister = () => {
       <hr />
 
       <div className={styles.contents}>
-        <div className={styles.formContainer}>
+        <div className={styles.formContainer} ref={formRef}>
           {activeTab === "student" ? (
             <StudentAccountRegisterForm
+              current={currentStudent}
+              setCurrent={setCurrentStudent}
               accounts={studentAccounts}
               setAccounts={setStudentAccounts}
+              editingIndex={editingStudentIndex}
+              setEditingIndex={setEditingStudentIndex}
+              initialStudent={initialStudent}
+              onFormDone={scrollToStudentTable}
             />
           ) : (
             <TeacherAccountRegisterForm
+              current={currentTeacher}
+              setCurrent={setCurrentTeacher}
               accounts={teacherAccounts}
               setAccounts={setTeacherAccounts}
+              editingIndex={editingTeacherIndex}
+              setEditingIndex={setEditingTeacherIndex}
+              initialTeacher={initialTeacher}
+              onFormDone={scrollToTeacherTable}
             />
           )}
         </div>
@@ -68,12 +171,27 @@ const AccountRegister = () => {
 
         {activeTab === "student" ? (
           <StudentAccountRegisterTable
+            setCurrent={setCurrentStudent}
+            setEditingIndex={setEditingStudentIndex}
             accounts={studentAccounts}
             setAccounts={setStudentAccounts}
+            onEditDone={scrollToForm}
+            tableRef={studentTableRef}
           />
         ) : (
-          <div>abcdefghijklmn</div>
+          <TeacherAccountRegisterTable
+            setCurrent={setCurrentTeacher}
+            setEditingIndex={setEditingTeacherIndex}
+            accounts={teacherAccounts}
+            setAccounts={setTeacherAccounts}
+            onEditDone={scrollToForm}
+            tableRef={teacherTableRef}
+          />
         )}
+
+        <button className={styles.button} onClick={handleSubmit}>
+          作成完了
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -134,12 +134,14 @@ const AccountRegister = () => {
 
         <div className={styles.toggleTab} data-active={activeTab}>
           <button
+            type="button"
             className={activeTab === "student" ? styles.tabActive : ""}
             onClick={() => setActiveTab("student")}
           >
             生徒
           </button>
           <button
+            type="button"
             className={activeTab === "teacher" ? styles.tabActive : ""}
             onClick={() => setActiveTab("teacher")}
           >
@@ -197,7 +199,7 @@ const AccountRegister = () => {
           />
         )}
 
-        <button className={styles.button} onClick={handleSubmit}>
+        <button type="button" className={styles.button} onClick={handleSubmit}>
           作成完了
         </button>
       </div>

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -68,12 +68,7 @@ const AccountRegister = () => {
     useState<StudentAccountRegisterType>(initialStudent);
 
   const [currentTeacher, setCurrentTeacher] =
-    useState<TeacherAccountRegisterType>({
-      name: "",
-      email: "",
-      password: "",
-      passwordConfirm: "",
-    });
+    useState<TeacherAccountRegisterType>(initialTeacher);
 
   const [studentAccounts, setStudentAccounts] = useState<
     StudentAccountRegisterType[]

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -3,15 +3,27 @@ import {
   StudentAccountRegisterForm,
   TeacherAccountRegisterForm,
 } from "@/features/management/components/accountRegisterForm/accountRegisterForm";
+import {
+  type StudentAccountRegisterType,
+  type TeacherAccountRegisterType,
+} from "@/features/management/types/account";
 import { useState } from "react";
 import { paths } from "@/config/paths";
 import styles from "@/features/management/style/accountRegister.module.css";
+import { StudentAccountRegisterTable } from "@/features/management/components/accountRegisterTable/accountRegisterTable";
 
 const AccountRegister = () => {
   const [activeTab, setActiveTab] = useState<"student" | "teacher">("student");
 
+  const [studentAccounts, setStudentAccounts] = useState<
+    StudentAccountRegisterType[]
+  >([]);
+  const [teacherAccounts, setTeacherAccounts] = useState<
+    TeacherAccountRegisterType[]
+  >([]);
+
   return (
-    <div className={styles.contents}>
+    <div className={styles.contentsContainer}>
       <BackPage
         to={paths.app.management.account.new.path}
         label="アカウント登録メニューに戻る"
@@ -37,11 +49,32 @@ const AccountRegister = () => {
 
       <hr />
 
-      {activeTab === "student" ? (
-        <StudentAccountRegisterForm />
-      ) : (
-        <TeacherAccountRegisterForm />
-      )}
+      <div className={styles.contents}>
+        <div className={styles.formContainer}>
+          {activeTab === "student" ? (
+            <StudentAccountRegisterForm
+              accounts={studentAccounts}
+              setAccounts={setStudentAccounts}
+            />
+          ) : (
+            <TeacherAccountRegisterForm
+              accounts={teacherAccounts}
+              setAccounts={setTeacherAccounts}
+            />
+          )}
+        </div>
+
+        <div></div>
+
+        {activeTab === "student" ? (
+          <StudentAccountRegisterTable
+            accounts={studentAccounts}
+            setAccounts={setStudentAccounts}
+          />
+        ) : (
+          <div>abcdefghijklmn</div>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -86,9 +86,7 @@ const AccountRegister = () => {
     null,
   );
 
-  useBlockNavigation(
-    teacherAccounts.length > 0 || studentAccounts.length > 0 ? true : false,
-  );
+  useBlockNavigation(teacherAccounts.length > 0 || studentAccounts.length > 0);
 
   useBeforeUnload(
     useCallback(

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -179,8 +179,6 @@ const AccountRegister = () => {
           )}
         </div>
 
-        <div></div>
-
         {activeTab === "student" ? (
           <StudentAccountRegisterTable
             setCurrent={setCurrentStudent}

--- a/frontend/src/app/routes/app/management/account/accountRegister.tsx
+++ b/frontend/src/app/routes/app/management/account/accountRegister.tsx
@@ -7,7 +7,9 @@ import {
   type StudentAccountRegisterType,
   type TeacherAccountRegisterType,
 } from "@/features/management/types/account";
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
+import { useBeforeUnload } from "react-router";
+import { useBlockNavigation } from "@/hooks/useBlockNavigation";
 import { paths } from "@/config/paths";
 import styles from "@/features/management/style/accountRegister.module.css";
 import {
@@ -87,6 +89,21 @@ const AccountRegister = () => {
 
   const [editingTeacherIndex, setEditingTeacherIndex] = useState<number | null>(
     null,
+  );
+
+  useBlockNavigation(
+    teacherAccounts.length > 0 || studentAccounts.length > 0 ? true : false,
+  );
+
+  useBeforeUnload(
+    useCallback(
+      (e) => {
+        if (teacherAccounts.length > 0 || studentAccounts.length > 0) {
+          e.preventDefault();
+        }
+      },
+      [studentAccounts, teacherAccounts],
+    ),
   );
 
   const handleSubmit = () => {

--- a/frontend/src/components/layouts/managementLayout/managementLayout.module.css
+++ b/frontend/src/components/layouts/managementLayout/managementLayout.module.css
@@ -14,7 +14,7 @@
   flex: 1;
   width: 100%;
   min-height: 0;
-  height: 100%; /* 追加：子要素の height:100% を確定させる */
+  height: 100%;
 }
 
 .containerOpen {
@@ -50,12 +50,13 @@
 
 .main {
   grid-area: main;
-  overflow-y: auto;
+  overflow: auto;
   display: flex;
   flex-direction: column;
   padding: 1rem 1.5rem;
   background-color: #f1f5f9;
   min-height: 0;
+  min-width: 0;
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/components/layouts/managementLayout/managementLayout.module.css
+++ b/frontend/src/components/layouts/managementLayout/managementLayout.module.css
@@ -7,25 +7,35 @@
 }
 
 .container {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: 60px 20px 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: "menu toggle main";
   flex: 1;
   width: 100%;
   min-height: 0;
+  height: 100%; /* 追加：子要素の height:100% を確定させる */
 }
 
-.menuContainer {
-  display: flex;
-  flex-direction: row;
+.containerOpen {
+  grid-template-columns: 60px 250px 1fr;
+  grid-template-areas: "menu drawer main";
+}
+
+.drawerWrapper {
+  grid-area: drawer;
   height: 100%;
+  min-height: 0;
 }
 
 .menuWrapper {
+  grid-area: menu;
   width: 60px;
   height: 100%;
 }
 
 .openDrawer {
+  grid-area: toggle;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,31 +49,26 @@
 }
 
 .main {
-  flex: 1;
+  grid-area: main;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   padding: 1rem 1.5rem;
   background-color: #f1f5f9;
+  min-height: 0;
 }
 
-/* 960px以下のレイアウト */
 @media (max-width: 960px) {
   .container {
-    flex-direction: column;
-  }
-
-  .contentContainer {
-    display: flex;
-    flex-direction: row;
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
+    grid-template-columns: 20px 1fr;
+    grid-template-rows: 1fr 60px;
+    grid-template-areas:
+      "toggle main"
+      "menu menu";
   }
 
   .menuWrapper {
     width: 100%;
     height: 60px;
-    flex-shrink: 0;
   }
 }

--- a/frontend/src/components/layouts/managementLayout/managementLayout.tsx
+++ b/frontend/src/components/layouts/managementLayout/managementLayout.tsx
@@ -3,7 +3,7 @@ import { Menu } from "@/components/ui/menu/menu";
 import { MenuDrawer } from "@/features/management/components/menuDrawer/menuDrawer";
 import { FaChevronRight } from "react-icons/fa";
 import styles from "./managementLayout.module.css";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 type Props = {
   children: React.ReactNode;
@@ -11,71 +11,40 @@ type Props = {
 
 export const ManagementLayout = ({ children }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [isMobile, setIsMobile] = useState<boolean>(false);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 960) {
-        setIsMobile(true);
-      } else {
-        setIsMobile(false);
-      }
-    };
-
-    handleResize();
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
 
   return (
     <div className={styles.layoutContainer}>
       <Header />
 
-      {!isMobile ? (
-        <div className={styles.container}>
-          <aside className={styles.menuContainer}>
-            <div className={styles.menuWrapper}>
-              <Menu />
-            </div>
-            <button
-              onClick={() => setIsOpen(true)}
-              className={
-                isOpen
-                  ? `${styles.openDrawer} ${styles.closeDrawer}`
-                  : styles.openDrawer
-              }
-            >
-              <FaChevronRight />
-            </button>
-            <MenuDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
-          </aside>
-
-          <main className={styles.main}>{children}</main>
+      <div
+        className={`${styles.container} ${isOpen ? styles.containerOpen : ""}`}
+      >
+        <div className={styles.menuWrapper}>
+          <Menu />
         </div>
-      ) : (
-        // 960px以下のレイアウト
-        <div className={styles.container}>
-          <div className={styles.contentContainer}>
-            <button
-              onClick={() => setIsOpen(true)}
-              className={styles.openDrawer}
-              style={isOpen ? { display: "none" } : { display: "flex" }}
-            >
-              <FaChevronRight />
-            </button>
-            <MenuDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
-            <main className={styles.main}>{children}</main>
-          </div>
 
-          <div className={styles.menuWrapper}>
-            <Menu />
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className={
+            isOpen
+              ? `${styles.openDrawer} ${styles.closeDrawer}`
+              : styles.openDrawer
+          }
+          aria-label="メニューを開く"
+          aria-expanded={isOpen}
+        >
+          <FaChevronRight />
+        </button>
+
+        {isOpen && (
+          <div className={styles.drawerWrapper}>
+            <MenuDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
           </div>
-        </div>
-      )}
+        )}
+
+        <main className={styles.main}>{children}</main>
+      </div>
     </div>
   );
 };

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
@@ -93,6 +93,7 @@
 
 .button {
   height: 38px;
+  width: 100%;
   padding: 5px 14px;
   border-radius: 6px;
   border: 1px solid transparent;
@@ -101,9 +102,14 @@
   background-color: rgb(56, 94, 164);
   color: #fff;
   cursor: pointer;
-
   flex: 0 0 auto;
   white-space: nowrap;
+}
+
+.buttonRowTwo .button {
+  width: auto;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .isError {
@@ -120,5 +126,10 @@
 
   .row .button {
     width: 100%;
+  }
+
+  .buttonRowTwo .button {
+    width: 100%;
+    flex: 0 0 auto;
   }
 }

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
@@ -1,0 +1,93 @@
+.registerForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  overflow-y: scroll;
+  background-color: #f1f5f9;
+  padding: 1rem;
+  box-sizing: border-box;
+  border-radius: 10px;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 1.5rem;
+  width: 100%;
+  align-items: flex-end;
+}
+
+.row > .input {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.rowTwoCols {
+  flex-wrap: wrap; /* 画面幅ではなく、行の実幅が足りない時に自動で折り返す */
+}
+
+.colName {
+  flex: 2 1 0;
+  min-width: min(240px, 100%); /* コンテナが240px未満でもはみ出さない */
+}
+
+.colGrade {
+  flex: 1 1 0;
+  min-width: min(140px, 100%); /* 同上 */
+}
+
+.input {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+}
+
+.input label {
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.input input,
+.input select {
+  width: 100%;
+  box-sizing: border-box;
+  height: 38px;
+  padding: 8px 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 5px;
+  background-color: #fff;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.button {
+  height: 38px;
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  background-color: rgb(56, 94, 164);
+  color: #fff;
+  cursor: pointer;
+
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .row {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: stretch;
+  }
+
+  .row .button {
+    width: 100%;
+  }
+}

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.module.css
@@ -4,7 +4,6 @@
   gap: 1rem;
   width: 100%;
   height: 100%;
-  overflow-y: scroll;
   background-color: #f1f5f9;
   padding: 1rem;
   box-sizing: border-box;
@@ -17,7 +16,7 @@
   flex-wrap: nowrap;
   gap: 1.5rem;
   width: 100%;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .row > .input {
@@ -26,17 +25,17 @@
 }
 
 .rowTwoCols {
-  flex-wrap: wrap; /* 画面幅ではなく、行の実幅が足りない時に自動で折り返す */
+  flex-wrap: wrap;
 }
 
 .colName {
   flex: 2 1 0;
-  min-width: min(240px, 100%); /* コンテナが240px未満でもはみ出さない */
+  min-width: min(240px, 100%);
 }
 
 .colGrade {
   flex: 1 1 0;
-  min-width: min(140px, 100%); /* 同上 */
+  min-width: min(140px, 100%);
 }
 
 .input {
@@ -65,6 +64,33 @@
   line-height: 1;
 }
 
+.inputWithIconInner {
+  position: relative;
+  width: 100%;
+}
+
+.inputWithIconInner input {
+  padding-right: 40px;
+}
+
+.eyeButton {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  font-size: 1.2rem;
+  height: 38px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: #334155;
+}
+
 .button {
   height: 38px;
   padding: 5px 14px;
@@ -78,6 +104,11 @@
 
   flex: 0 0 auto;
   white-space: nowrap;
+}
+
+.isError {
+  color: red;
+  font-size: 0.9rem;
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import {
   type StudentAccountRegisterType,
@@ -12,20 +12,37 @@ type ShowPassConfigsType = {
 };
 
 type StudentFormProps = {
+  current: StudentAccountRegisterType;
+  setCurrent: (current: StudentAccountRegisterType) => void;
   accounts: StudentAccountRegisterType[];
   setAccounts: (accounts: StudentAccountRegisterType[]) => void;
+  editingIndex: number | null;
+  setEditingIndex: (index: number | null) => void;
+  initialStudent: StudentAccountRegisterType;
+  onFormDone: (index: number | null) => void;
 };
 
 export const StudentAccountRegisterForm = ({
+  current,
+  setCurrent,
   accounts,
   setAccounts,
+  editingIndex,
+  setEditingIndex,
+  initialStudent,
+  onFormDone,
 }: StudentFormProps) => {
   const {
     register,
     handleSubmit,
     getValues,
+    reset,
     formState: { errors },
   } = useForm<StudentAccountRegisterType>();
+
+  useEffect(() => {
+    reset(current);
+  }, [current, reset]);
 
   const [show, setShow] = useState<ShowPassConfigsType>({
     1: false,
@@ -40,8 +57,22 @@ export const StudentAccountRegisterForm = ({
   };
 
   const onSubmit = (formDate: StudentAccountRegisterType) => {
-    console.log(formDate);
-    setAccounts([...accounts, formDate]);
+    const targetIndex = editingIndex !== null ? editingIndex : accounts.length;
+
+    if (editingIndex !== null) {
+      const next = accounts.map((a, i) => (i === editingIndex ? formDate : a));
+      setAccounts(next);
+      setEditingIndex(null);
+    } else {
+      setAccounts([...accounts, formDate]);
+    }
+
+    setCurrent(initialStudent);
+    reset(initialStudent);
+
+    requestAnimationFrame(() => {
+      onFormDone(targetIndex);
+    });
   };
 
   return (
@@ -177,7 +208,16 @@ export const StudentAccountRegisterForm = ({
           <input
             id="graduateDate"
             type="date"
-            {...register("graduateDate", { required: "この項目は必須です" })}
+            {...register("graduateDate", {
+              required: "この項目は必須です",
+              validate: (date) => {
+                const entryDate = new Date(getValues("entryDate"));
+                const graduateDate = new Date(date);
+
+                if (entryDate > graduateDate)
+                  return "入学時期より後の日付を設定してください";
+              },
+            })}
           />
           {errors.graduateDate?.message && (
             <p className={styles.isError}>{errors.graduateDate.message}</p>
@@ -185,28 +225,63 @@ export const StudentAccountRegisterForm = ({
         </div>
       </div>
 
-      <button className={styles.button} type="submit">
-        追加
-      </button>
+      <div
+        className={`${styles.row} ${editingIndex !== null ? styles.buttonRowTwo : ""}`}
+      >
+        <button className={styles.button} type="submit">
+          {editingIndex !== null ? "更新" : "追加"}
+        </button>
+
+        {editingIndex !== null ? (
+          <button
+            className={styles.button}
+            type="button"
+            onClick={() => {
+              setEditingIndex(null);
+              setCurrent(initialStudent);
+              reset(initialStudent);
+            }}
+          >
+            キャンセル
+          </button>
+        ) : null}
+      </div>
     </form>
   );
 };
 
 type TeacherFormProps = {
+  current: TeacherAccountRegisterType;
+  setCurrent: (current: TeacherAccountRegisterType) => void;
   accounts: TeacherAccountRegisterType[];
   setAccounts: (accounts: TeacherAccountRegisterType[]) => void;
+  editingIndex: number | null;
+  setEditingIndex: (index: number | null) => void;
+  initialTeacher: TeacherAccountRegisterType;
+  onFormDone: (index: number | null) => void;
 };
 
 export const TeacherAccountRegisterForm = ({
+  current,
+  setCurrent,
   accounts,
   setAccounts,
+  editingIndex,
+  setEditingIndex,
+  initialTeacher,
+  onFormDone,
 }: TeacherFormProps) => {
   const {
     register,
     handleSubmit,
     getValues,
+    reset,
     formState: { errors },
   } = useForm<TeacherAccountRegisterType>();
+
+  useEffect(() => {
+    reset(current);
+  }, [current, reset]);
 
   const [show, setShow] = useState<ShowPassConfigsType>({
     1: false,
@@ -222,7 +297,23 @@ export const TeacherAccountRegisterForm = ({
 
   const onSubmit = (formDate: TeacherAccountRegisterType) => {
     console.log(formDate);
-    setAccounts([...accounts, formDate]);
+
+    const targetIndex = editingIndex !== null ? editingIndex : accounts.length;
+
+    if (editingIndex !== null) {
+      const next = accounts.map((a, i) => (i === editingIndex ? formDate : a));
+      setAccounts(next);
+      setEditingIndex(null);
+    } else {
+      setAccounts([...accounts, formDate]);
+    }
+
+    setCurrent(initialTeacher);
+    reset(initialTeacher);
+
+    requestAnimationFrame(() => {
+      onFormDone(targetIndex);
+    });
   };
 
   return (
@@ -321,9 +412,27 @@ export const TeacherAccountRegisterForm = ({
         </div>
       </div>
 
-      <button className={styles.button} type="submit">
-        追加
-      </button>
+      <div
+        className={`${styles.row} ${editingIndex !== null ? styles.buttonRowTwo : ""}`}
+      >
+        <button className={styles.button} type="submit">
+          {editingIndex !== null ? "更新" : "追加"}
+        </button>
+
+        {editingIndex !== null ? (
+          <button
+            className={styles.button}
+            type="button"
+            onClick={() => {
+              setEditingIndex(null);
+              setCurrent(initialTeacher);
+              reset(initialTeacher);
+            }}
+          >
+            キャンセル
+          </button>
+        ) : null}
+      </div>
     </form>
   );
 };

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -172,6 +172,8 @@ export const StudentAccountRegisterForm = ({
                   if (pass !== getValues("password")) {
                     return "パスワードが一致しません";
                   }
+
+                  return true;
                 },
                 required: "確認は必須です",
               })}

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -1,9 +1,51 @@
 import { useForm } from "react-hook-form";
+import { useState } from "react";
+import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
+import {
+  type StudentAccountRegisterType,
+  type TeacherAccountRegisterType,
+} from "../../types/account";
 import styles from "./accountRegisterForm.module.css";
 
-export const StudentAccountRegisterForm = () => {
+type ShowPassConfigsType = {
+  [key: number]: boolean;
+};
+
+type StudentFormProps = {
+  accounts: StudentAccountRegisterType[];
+  setAccounts: (accounts: StudentAccountRegisterType[]) => void;
+};
+
+export const StudentAccountRegisterForm = ({
+  accounts,
+  setAccounts,
+}: StudentFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm<StudentAccountRegisterType>();
+
+  const [show, setShow] = useState<ShowPassConfigsType>({
+    1: false,
+    2: false,
+  });
+
+  const toggleConfig = (targetId: number) => {
+    setShow((prev) => ({
+      ...prev,
+      [targetId]: !prev[targetId],
+    }));
+  };
+
+  const onSubmit = (formDate: StudentAccountRegisterType) => {
+    console.log(formDate);
+    setAccounts([...accounts, formDate]);
+  };
+
   return (
-    <form className={styles.registerForm}>
+    <form className={styles.registerForm} onSubmit={handleSubmit(onSubmit)}>
       <div className={styles.row}>
         <div className={`${styles.input} ${styles.colName}`}>
           <label htmlFor="accountName">名前</label>
@@ -11,11 +53,11 @@ export const StudentAccountRegisterForm = () => {
             id="accountName"
             type="text"
             placeholder="名前を入力..."
-            //   {...register("name", { required: "ユーザー名は必須です" })}
+            {...register("name", { required: "ユーザー名は必須です" })}
           />
-          {/* {errors.name?.message && (
-          <p className={styles.isError}>{errors.name.message}</p>
-        )} */}
+          {errors.name?.message && (
+            <p className={styles.isError}>{errors.name.message}</p>
+          )}
         </div>
         <div className={`${styles.input} ${styles.colGrade}`}>
           <label htmlFor="grade">学年</label>
@@ -23,18 +65,18 @@ export const StudentAccountRegisterForm = () => {
             id="grade"
             type="number"
             placeholder="数字で入力..."
-            //   {...register("grade", {
-            //     required: "学年は必須です",
-            //     valueAsNumber: true,
-            //     min: {
-            //       value: 1,
-            //       message: "1以上の数値を入力してください",
-            //     },
-            //   })}
+            {...register("grade", {
+              required: "学年は必須です",
+              valueAsNumber: true,
+              min: {
+                value: 1,
+                message: "1以上の数値を入力してください",
+              },
+            })}
           />
-          {/* {errors.grade?.message && (
-          <p className={styles.isError}>{errors.grade.message}</p>
-        )} */}
+          {errors.grade?.message && (
+            <p className={styles.isError}>{errors.grade.message}</p>
+          )}
         </div>
       </div>
 
@@ -44,47 +86,77 @@ export const StudentAccountRegisterForm = () => {
           id="email"
           type="email"
           placeholder="メールアドレスを入力..."
-          //   {...register("email", {
-          //     required: "メールアドレスは必須です",
-          //     pattern: {
-          //       value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
-          //       message:
-          //         "有効なメールアドレスを入力してください（例: school@example.com）",
-          //     },
-          //   })}
+          {...register("email", {
+            required: "メールアドレスは必須です",
+            pattern: {
+              value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
+              message:
+                "有効なメールアドレスを入力してください（例: school@example.com）",
+            },
+          })}
         />
-        {/* {errors.email?.message && (
+        {errors.email?.message && (
           <p className={styles.isError}>{errors.email.message}</p>
-        )} */}
+        )}
       </div>
 
       <div className={styles.row}>
         <div className={styles.input}>
           <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            type="password"
-            placeholder="パスワードを入力..."
-            //   {...register("password", { required: "パスワードは必須です" })}
-          />
-          {/* {errors.password?.message && (
-          <p className={styles.isError}>{errors.password.message}</p>
-        )} */}
+
+          <div className={styles.inputWithIconInner}>
+            <input
+              id="password"
+              type={!show[1] ? "password" : "text"}
+              autoComplete="new-password"
+              placeholder="パスワードを入力..."
+              {...register("password", { required: "パスワードは必須です" })}
+            />
+
+            <button
+              type="button"
+              className={styles.eyeButton}
+              onClick={() => toggleConfig(1)}
+              aria-label={!show[1] ? "パスワードを表示" : "パスワードを非表示"}
+            >
+              {!show[1] ? <FaRegEye /> : <FaRegEyeSlash />}
+            </button>
+          </div>
+
+          {errors.password?.message && (
+            <p className={styles.isError}>{errors.password.message}</p>
+          )}
         </div>
-        <button className={styles.button} type="button">
-          パスワード生成
-        </button>
+
         <div className={styles.input}>
           <label htmlFor="passwordConfirm">パスワード（確認用）</label>
-          <input
-            id="passwordConfirm"
-            type="password"
-            placeholder="パスワード（確認用）を入力..."
-            //   {...register("passwordConfirm", { required: "確認は必須です" })}
-          />
-          {/* {errors.passwordConfirm?.message && (
-          <p className={styles.isError}>{errors.passwordConfirm.message}</p>
-        )} */}
+
+          <div className={styles.inputWithIconInner}>
+            <input
+              id="passwordConfirm"
+              type={!show[2] ? "password" : "text"}
+              placeholder="パスワード（確認用）を入力..."
+              {...register("passwordConfirm", {
+                validate: (pass) => {
+                  if (pass !== getValues("password")) {
+                    return "パスワードが一致しません";
+                  }
+                },
+                required: "確認は必須です",
+              })}
+            />
+            <button
+              type="button"
+              className={styles.eyeButton}
+              onClick={() => toggleConfig(2)}
+              aria-label={!show[2] ? "パスワードを表示" : "パスワードを非表示"}
+            >
+              {!show[2] ? <FaRegEye /> : <FaRegEyeSlash />}
+            </button>
+          </div>
+          {errors.passwordConfirm?.message && (
+            <p className={styles.isError}>{errors.passwordConfirm.message}</p>
+          )}
         </div>
       </div>
 
@@ -94,22 +166,22 @@ export const StudentAccountRegisterForm = () => {
           <input
             id="entryDate"
             type="date"
-            //{...register("entryDate", { required: "この項目は必須です" })}
+            {...register("entryDate", { required: "この項目は必須です" })}
           />
-          {/* {errors.entryDate?.message && (
-          <p className={styles.isError}>{errors.entryDate.message}</p>
-        )} */}
+          {errors.entryDate?.message && (
+            <p className={styles.isError}>{errors.entryDate.message}</p>
+          )}
         </div>
         <div className={styles.input}>
-          <label htmlFor="expectedGraduation">卒業見込み</label>
+          <label htmlFor="graduateDate">卒業見込み</label>
           <input
-            id="expectedGraduation"
+            id="graduateDate"
             type="date"
-            //{...register("graduateDate", { required: "この項目は必須です" })}
+            {...register("graduateDate", { required: "この項目は必須です" })}
           />
-          {/* {errors.graduateDate?.message && (
-          <p className={styles.isError}>{errors.graduateDate.message}</p>
-        )} */}
+          {errors.graduateDate?.message && (
+            <p className={styles.isError}>{errors.graduateDate.message}</p>
+          )}
         </div>
       </div>
 
@@ -120,6 +192,138 @@ export const StudentAccountRegisterForm = () => {
   );
 };
 
-export const TeacherAccountRegisterForm = () => {
-  return <form className={styles.registerForm}>Teacher</form>;
+type TeacherFormProps = {
+  accounts: TeacherAccountRegisterType[];
+  setAccounts: (accounts: TeacherAccountRegisterType[]) => void;
+};
+
+export const TeacherAccountRegisterForm = ({
+  accounts,
+  setAccounts,
+}: TeacherFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm<TeacherAccountRegisterType>();
+
+  const [show, setShow] = useState<ShowPassConfigsType>({
+    1: false,
+    2: false,
+  });
+
+  const toggleConfig = (targetId: number) => {
+    setShow((prev) => ({
+      ...prev,
+      [targetId]: !prev[targetId],
+    }));
+  };
+
+  const onSubmit = (formDate: TeacherAccountRegisterType) => {
+    console.log(formDate);
+    setAccounts([...accounts, formDate]);
+  };
+
+  return (
+    <form className={styles.registerForm} onSubmit={handleSubmit(onSubmit)}>
+      <div className={styles.row}>
+        <div className={`${styles.input} ${styles.colName}`}>
+          <label htmlFor="accountName">名前</label>
+          <input
+            id="accountName"
+            type="text"
+            placeholder="名前を入力..."
+            {...register("name", { required: "ユーザー名は必須です" })}
+          />
+          {errors.name?.message && (
+            <p className={styles.isError}>{errors.name.message}</p>
+          )}
+        </div>
+        <div className={styles.input}>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            placeholder="メールアドレスを入力..."
+            {...register("email", {
+              required: "メールアドレスは必須です",
+              pattern: {
+                value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
+                message:
+                  "有効なメールアドレスを入力してください（例: school@example.com）",
+              },
+            })}
+          />
+          {errors.email?.message && (
+            <p className={styles.isError}>{errors.email.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.row}>
+        <div className={styles.input}>
+          <label htmlFor="password">パスワード</label>
+
+          <div className={styles.inputWithIconInner}>
+            <input
+              id="password"
+              type={!show[1] ? "password" : "text"}
+              autoComplete="new-password"
+              placeholder="パスワードを入力..."
+              {...register("password", { required: "パスワードは必須です" })}
+            />
+
+            <button
+              type="button"
+              className={styles.eyeButton}
+              onClick={() => toggleConfig(1)}
+              aria-label={!show[1] ? "パスワードを表示" : "パスワードを非表示"}
+            >
+              {!show[1] ? <FaRegEye /> : <FaRegEyeSlash />}
+            </button>
+          </div>
+
+          {errors.password?.message && (
+            <p className={styles.isError}>{errors.password.message}</p>
+          )}
+        </div>
+
+        <div className={styles.input}>
+          <label htmlFor="passwordConfirm">パスワード（確認用）</label>
+
+          <div className={styles.inputWithIconInner}>
+            <input
+              id="passwordConfirm"
+              type={!show[2] ? "password" : "text"}
+              placeholder="パスワード（確認用）を入力..."
+              {...register("passwordConfirm", {
+                validate: (pass) => {
+                  if (pass !== getValues("password")) {
+                    return "パスワードが一致しません";
+                  }
+                },
+                required: "確認は必須です",
+              })}
+            />
+            <button
+              type="button"
+              className={styles.eyeButton}
+              onClick={() => toggleConfig(2)}
+              aria-label={!show[2] ? "パスワードを表示" : "パスワードを非表示"}
+            >
+              {!show[2] ? <FaRegEye /> : <FaRegEyeSlash />}
+            </button>
+          </div>
+          {errors.passwordConfirm?.message && (
+            <p className={styles.isError}>{errors.passwordConfirm.message}</p>
+          )}
+        </div>
+      </div>
+
+      <button className={styles.button} type="submit">
+        追加
+      </button>
+    </form>
+  );
 };

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -216,6 +216,8 @@ export const StudentAccountRegisterForm = ({
 
                 if (entryDate > graduateDate)
                   return "入学時期より後の日付を設定してください";
+
+                return true;
               },
             })}
           />
@@ -393,6 +395,8 @@ export const TeacherAccountRegisterForm = ({
                   if (pass !== getValues("password")) {
                     return "パスワードが一致しません";
                   }
+
+                  return true;
                 },
                 required: "確認は必須です",
               })}

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -56,15 +56,15 @@ export const StudentAccountRegisterForm = ({
     }));
   };
 
-  const onSubmit = (formDate: StudentAccountRegisterType) => {
+  const onSubmit = (formData: StudentAccountRegisterType) => {
     const targetIndex = editingIndex !== null ? editingIndex : accounts.length;
 
     if (editingIndex !== null) {
-      const next = accounts.map((a, i) => (i === editingIndex ? formDate : a));
+      const next = accounts.map((a, i) => (i === editingIndex ? formData : a));
       setAccounts(next);
       setEditingIndex(null);
     } else {
-      setAccounts([...accounts, formDate]);
+      setAccounts([...accounts, formData]);
     }
 
     setCurrent(initialStudent);
@@ -299,17 +299,17 @@ export const TeacherAccountRegisterForm = ({
     }));
   };
 
-  const onSubmit = (formDate: TeacherAccountRegisterType) => {
-    console.log(formDate);
+  const onSubmit = (formData: TeacherAccountRegisterType) => {
+    console.log(formData);
 
     const targetIndex = editingIndex !== null ? editingIndex : accounts.length;
 
     if (editingIndex !== null) {
-      const next = accounts.map((a, i) => (i === editingIndex ? formDate : a));
+      const next = accounts.map((a, i) => (i === editingIndex ? formData : a));
       setAccounts(next);
       setEditingIndex(null);
     } else {
-      setAccounts([...accounts, formDate]);
+      setAccounts([...accounts, formData]);
     }
 
     setCurrent(initialTeacher);

--- a/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
+++ b/frontend/src/features/management/components/accountRegisterForm/accountRegisterForm.tsx
@@ -1,0 +1,125 @@
+import { useForm } from "react-hook-form";
+import styles from "./accountRegisterForm.module.css";
+
+export const StudentAccountRegisterForm = () => {
+  return (
+    <form className={styles.registerForm}>
+      <div className={styles.row}>
+        <div className={`${styles.input} ${styles.colName}`}>
+          <label htmlFor="accountName">名前</label>
+          <input
+            id="accountName"
+            type="text"
+            placeholder="名前を入力..."
+            //   {...register("name", { required: "ユーザー名は必須です" })}
+          />
+          {/* {errors.name?.message && (
+          <p className={styles.isError}>{errors.name.message}</p>
+        )} */}
+        </div>
+        <div className={`${styles.input} ${styles.colGrade}`}>
+          <label htmlFor="grade">学年</label>
+          <input
+            id="grade"
+            type="number"
+            placeholder="数字で入力..."
+            //   {...register("grade", {
+            //     required: "学年は必須です",
+            //     valueAsNumber: true,
+            //     min: {
+            //       value: 1,
+            //       message: "1以上の数値を入力してください",
+            //     },
+            //   })}
+          />
+          {/* {errors.grade?.message && (
+          <p className={styles.isError}>{errors.grade.message}</p>
+        )} */}
+        </div>
+      </div>
+
+      <div className={styles.input}>
+        <label htmlFor="email">メールアドレス</label>
+        <input
+          id="email"
+          type="email"
+          placeholder="メールアドレスを入力..."
+          //   {...register("email", {
+          //     required: "メールアドレスは必須です",
+          //     pattern: {
+          //       value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
+          //       message:
+          //         "有効なメールアドレスを入力してください（例: school@example.com）",
+          //     },
+          //   })}
+        />
+        {/* {errors.email?.message && (
+          <p className={styles.isError}>{errors.email.message}</p>
+        )} */}
+      </div>
+
+      <div className={styles.row}>
+        <div className={styles.input}>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            placeholder="パスワードを入力..."
+            //   {...register("password", { required: "パスワードは必須です" })}
+          />
+          {/* {errors.password?.message && (
+          <p className={styles.isError}>{errors.password.message}</p>
+        )} */}
+        </div>
+        <button className={styles.button} type="button">
+          パスワード生成
+        </button>
+        <div className={styles.input}>
+          <label htmlFor="passwordConfirm">パスワード（確認用）</label>
+          <input
+            id="passwordConfirm"
+            type="password"
+            placeholder="パスワード（確認用）を入力..."
+            //   {...register("passwordConfirm", { required: "確認は必須です" })}
+          />
+          {/* {errors.passwordConfirm?.message && (
+          <p className={styles.isError}>{errors.passwordConfirm.message}</p>
+        )} */}
+        </div>
+      </div>
+
+      <div className={styles.row}>
+        <div className={styles.input}>
+          <label htmlFor="entryDate">入学時期</label>
+          <input
+            id="entryDate"
+            type="date"
+            //{...register("entryDate", { required: "この項目は必須です" })}
+          />
+          {/* {errors.entryDate?.message && (
+          <p className={styles.isError}>{errors.entryDate.message}</p>
+        )} */}
+        </div>
+        <div className={styles.input}>
+          <label htmlFor="expectedGraduation">卒業見込み</label>
+          <input
+            id="expectedGraduation"
+            type="date"
+            //{...register("graduateDate", { required: "この項目は必須です" })}
+          />
+          {/* {errors.graduateDate?.message && (
+          <p className={styles.isError}>{errors.graduateDate.message}</p>
+        )} */}
+        </div>
+      </div>
+
+      <button className={styles.button} type="submit">
+        追加
+      </button>
+    </form>
+  );
+};
+
+export const TeacherAccountRegisterForm = () => {
+  return <form className={styles.registerForm}>Teacher</form>;
+};

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
@@ -1,0 +1,129 @@
+.accountTableContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.tableScroll {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.accountTable {
+  min-width: 49rem;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: #fff;
+  table-layout: fixed;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+}
+
+.accountTable th,
+.accountTable td {
+  box-sizing: border-box;
+  vertical-align: middle;
+}
+
+.accountTable th,
+.accountTable td {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.accountTable thead th:nth-child(1),
+.accountTable tbody td:nth-child(1) {
+  width: 9rem;
+}
+
+.accountTable thead th:nth-child(2),
+.accountTable tbody td:nth-child(2) {
+  width: 3.5rem;
+  text-align: center;
+}
+
+.accountTable thead th:nth-child(3),
+.accountTable tbody td:nth-child(3) {
+  width: 12rem;
+}
+
+.accountTable thead th:nth-child(4),
+.accountTable tbody td:nth-child(4) {
+  width: 7rem;
+}
+
+.accountTable thead th:nth-child(5),
+.accountTable tbody td:nth-child(5),
+.accountTable thead th:nth-child(6),
+.accountTable tbody td:nth-child(6) {
+  width: 6.5rem;
+  text-align: center;
+}
+
+.accountTable thead th:nth-child(7),
+.accountTable tbody td:nth-child(7) {
+  width: 4.5rem;
+  text-align: center;
+}
+
+.actionsInner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  width: 100%;
+}
+
+.accountTable thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: rgb(50, 85, 150);
+  color: #fff;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid rgb(56, 94, 164);
+}
+
+.accountTable tbody td {
+  padding: 0.55rem 0.6rem;
+  border-bottom: 1px solid #eef2f7;
+  font-size: 0.9rem;
+}
+
+.actionsHead {
+  text-align: center;
+}
+
+.passwordCol {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.actionButton {
+  font-size: 1.2rem;
+  height: 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: #334155;
+  border-radius: 9999px;
+}
+
+.actionButton:hover {
+  background-color: #f1f5f9;
+}

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
@@ -44,10 +44,6 @@
   text-overflow: ellipsis;
 }
 
-.student .accountTable {
-  min-width: 49rem;
-}
-
 .student .accountTable :is(thead th, tbody td):nth-child(1) {
   width: 9rem;
 }
@@ -74,9 +70,6 @@
   text-align: center;
 }
 
-.teacher .accountTable {
-  min-width: 28rem;
-}
 .teacher .accountTable :is(thead th, tbody td):nth-child(1) {
   width: 9rem;
 }

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.module.css
@@ -2,92 +2,109 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
   min-width: 0;
+}
+
+.student {
+}
+.teacher {
 }
 
 .tableScroll {
   width: 100%;
+  min-width: 0;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow-y: visible;
 }
 
 .accountTable {
-  min-width: 49rem;
   width: 100%;
+  table-layout: auto;
   border-collapse: separate;
   border-spacing: 0;
   background: #fff;
-  table-layout: fixed;
   border: 1px solid #e2e8f0;
   border-radius: 10px;
 }
 
-.accountTable th,
-.accountTable td {
-  box-sizing: border-box;
-  vertical-align: middle;
+.student .accountTable {
+  min-width: 49rem;
 }
 
-.accountTable th,
-.accountTable td {
+.teacher .accountTable {
+  min-width: 28rem;
+}
+
+.accountTable :is(th, td) {
+  box-sizing: border-box;
+  vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.accountTable thead th:nth-child(1),
-.accountTable tbody td:nth-child(1) {
-  width: 9rem;
+.student .accountTable {
+  min-width: 49rem;
 }
 
-.accountTable thead th:nth-child(2),
-.accountTable tbody td:nth-child(2) {
+.student .accountTable :is(thead th, tbody td):nth-child(1) {
+  width: 9rem;
+}
+.student .accountTable :is(thead th, tbody td):nth-child(2) {
   width: 3.5rem;
   text-align: center;
 }
-
-.accountTable thead th:nth-child(3),
-.accountTable tbody td:nth-child(3) {
+.student .accountTable :is(thead th, tbody td):nth-child(3) {
   width: 12rem;
 }
-
-.accountTable thead th:nth-child(4),
-.accountTable tbody td:nth-child(4) {
+.student .accountTable :is(thead th, tbody td):nth-child(4) {
   width: 7rem;
 }
-
-.accountTable thead th:nth-child(5),
-.accountTable tbody td:nth-child(5),
-.accountTable thead th:nth-child(6),
-.accountTable tbody td:nth-child(6) {
+.student .accountTable :is(thead th, tbody td):nth-child(5) {
   width: 6.5rem;
   text-align: center;
 }
-
-.accountTable thead th:nth-child(7),
-.accountTable tbody td:nth-child(7) {
+.student .accountTable :is(thead th, tbody td):nth-child(6) {
+  width: 6.5rem;
+  text-align: center;
+}
+.student .accountTable :is(thead th, tbody td):nth-child(7) {
   width: 4.5rem;
   text-align: center;
 }
 
-.actionsInner {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.8rem;
-  width: 100%;
+.teacher .accountTable {
+  min-width: 28rem;
+}
+.teacher .accountTable :is(thead th, tbody td):nth-child(1) {
+  width: 9rem;
+}
+.teacher .accountTable :is(thead th, tbody td):nth-child(2) {
+  width: 14rem;
+}
+.teacher .accountTable :is(thead th, tbody td):nth-child(3) {
+  width: 7rem;
+}
+.teacher .accountTable :is(thead th, tbody td):nth-child(4) {
+  width: 4.5rem;
+  text-align: center;
 }
 
 .accountTable thead th {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   background: rgb(50, 85, 150);
   color: #fff;
   text-align: left;
   padding: 0.45rem 0.6rem;
   font-size: 0.9rem;
-  border-bottom: 1px solid rgb(56, 94, 164);
+  border-bottom: 2px solid rgb(56, 94, 164);
+}
+
+.accountTable thead th + th {
+  border-left: 1px solid rgba(255, 255, 255, 0.25);
 }
 
 .accountTable tbody td {
@@ -100,13 +117,24 @@
   text-align: center;
 }
 
+.actionsCell {
+  text-align: center;
+}
+
+.actionsInner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  width: 100%;
+}
+
 .passwordCol {
   display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
+  height: 100%;
 }
 
 .actionButton {

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
@@ -84,7 +84,6 @@ export const StudentAccountRegisterTable = ({
               return (
                 <tr
                   key={index}
-                  tabIndex={0}
                   ref={(e) => {
                     tableRef.current[index] = e;
                   }}
@@ -221,7 +220,6 @@ export const TeacherAccountRegisterTable = ({
               return (
                 <tr
                   key={index}
-                  tabIndex={0}
                   ref={(e) => {
                     tableRef.current[index] = e;
                   }}

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
@@ -1,7 +1,10 @@
-import { type StudentAccountRegisterType } from "../../types/account";
+import {
+  type StudentAccountRegisterType,
+  type TeacherAccountRegisterType,
+} from "../../types/account";
 import { MdEdit } from "react-icons/md";
 import { FaRegEye, FaRegEyeSlash, FaRegTrashAlt } from "react-icons/fa";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./accountRegisterTable.module.css";
 
 type ShowPassConfigsType = {
@@ -9,13 +12,21 @@ type ShowPassConfigsType = {
 };
 
 type StudentRegisterTableProps = {
+  setCurrent: (current: StudentAccountRegisterType) => void;
+  setEditingIndex: (index: number | null) => void;
   accounts: StudentAccountRegisterType[];
   setAccounts: (accounts: StudentAccountRegisterType[]) => void;
+  onEditDone?: () => void;
+  tableRef: React.RefObject<(HTMLTableRowElement | null)[]>;
 };
 
 export const StudentAccountRegisterTable = ({
+  setCurrent,
+  setEditingIndex,
   accounts,
   setAccounts,
+  onEditDone,
+  tableRef,
 }: StudentRegisterTableProps) => {
   const [show, setShow] = useState<ShowPassConfigsType>({});
 
@@ -36,8 +47,23 @@ export const StudentAccountRegisterTable = ({
     }));
   };
 
+  const handleEdit = (account: StudentAccountRegisterType, index: number) => {
+    setCurrent({ ...account });
+    setEditingIndex(index);
+
+    requestAnimationFrame(() => {
+      onEditDone?.();
+    });
+  };
+
+  const handleDelete = (account: StudentAccountRegisterType) => {
+    const newAccounts = accounts.filter((a) => a !== account);
+    setAccounts(newAccounts);
+    setEditingIndex(null);
+  };
+
   return (
-    <div className={styles.accountTableContainer}>
+    <div className={`${styles.accountTableContainer} ${styles.student}`}>
       <h3 className={styles.sectionName}>登録プレビュー</h3>
 
       <div className={styles.tableScroll}>
@@ -56,7 +82,13 @@ export const StudentAccountRegisterTable = ({
           <tbody>
             {accounts.map((account, index) => {
               return (
-                <tr key={index} tabIndex={0}>
+                <tr
+                  key={index}
+                  tabIndex={0}
+                  ref={(e) => {
+                    tableRef.current[index] = e;
+                  }}
+                >
                   <td>{account.name}</td>
                   <td>{account.grade}</td>
                   <td>{account.email}</td>
@@ -95,6 +127,7 @@ export const StudentAccountRegisterTable = ({
                         type="button"
                         className={styles.actionButton}
                         title="編集"
+                        onClick={() => handleEdit(account, index)}
                       >
                         <MdEdit color="rgb(56, 94, 164)" />
                       </button>
@@ -102,6 +135,141 @@ export const StudentAccountRegisterTable = ({
                         type="button"
                         className={styles.actionButton}
                         title="削除"
+                        onClick={() => handleDelete(account)}
+                      >
+                        <FaRegTrashAlt color="#fa5959" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+type TeacherRegisterTableProps = {
+  setCurrent: (current: TeacherAccountRegisterType) => void;
+  setEditingIndex: (index: number | null) => void;
+  accounts: TeacherAccountRegisterType[];
+  setAccounts: (accounts: TeacherAccountRegisterType[]) => void;
+  onEditDone?: () => void;
+  tableRef: React.RefObject<(HTMLTableRowElement | null)[]>;
+};
+
+export const TeacherAccountRegisterTable = ({
+  setCurrent,
+  setEditingIndex,
+  accounts,
+  setAccounts,
+  onEditDone,
+  tableRef,
+}: TeacherRegisterTableProps) => {
+  const [show, setShow] = useState<ShowPassConfigsType>({});
+
+  useEffect(() => {
+    setShow(() => {
+      const next: ShowPassConfigsType = {};
+      accounts.forEach((_, index) => {
+        next[index] = false;
+      });
+      return next;
+    });
+  }, [accounts]);
+
+  const toggleConfig = (targetId: number) => {
+    setShow((prev) => ({
+      ...prev,
+      [targetId]: !prev[targetId],
+    }));
+  };
+
+  const handleEdit = (account: TeacherAccountRegisterType, index: number) => {
+    setCurrent({ ...account });
+    setEditingIndex(index);
+
+    requestAnimationFrame(() => {
+      onEditDone?.();
+    });
+  };
+
+  const handleDelete = (account: TeacherAccountRegisterType) => {
+    const newAccounts = accounts.filter((a) => a !== account);
+    setAccounts(newAccounts);
+    setEditingIndex(null);
+  };
+
+  return (
+    <div className={`${styles.accountTableContainer} ${styles.teacher}`}>
+      <h3 className={styles.sectionName}>登録プレビュー</h3>
+
+      <div className={styles.tableScroll}>
+        <table className={styles.accountTable}>
+          <thead>
+            <tr>
+              <th>名前</th>
+              <th>メールアドレス</th>
+              <th>パスワード</th>
+              <th className={styles.actionsHead}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((account, index) => {
+              return (
+                <tr
+                  key={index}
+                  tabIndex={0}
+                  ref={(e) => {
+                    tableRef.current[index] = e;
+                  }}
+                >
+                  <td>{account.name}</td>
+                  <td>{account.email}</td>
+                  <td>
+                    <div className={styles.passwordCol}>
+                      {show[index] ? (
+                        <>
+                          <span>{account.password}</span>
+                          <button
+                            type="button"
+                            className={styles.actionButton}
+                            onClick={() => toggleConfig(index)}
+                          >
+                            <FaRegEye />
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <span>{"********"}</span>
+                          <button
+                            type="button"
+                            className={styles.actionButton}
+                            onClick={() => toggleConfig(index)}
+                          >
+                            <FaRegEyeSlash />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                  <td className={styles.actionsCell}>
+                    <div className={styles.actionsInner}>
+                      <button
+                        type="button"
+                        className={styles.actionButton}
+                        title="編集"
+                        onClick={() => handleEdit(account, index)}
+                      >
+                        <MdEdit color="rgb(56, 94, 164)" />
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.actionButton}
+                        title="削除"
+                        onClick={() => handleDelete(account)}
                       >
                         <FaRegTrashAlt color="#fa5959" />
                       </button>

--- a/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
+++ b/frontend/src/features/management/components/accountRegisterTable/accountRegisterTable.tsx
@@ -1,0 +1,118 @@
+import { type StudentAccountRegisterType } from "../../types/account";
+import { MdEdit } from "react-icons/md";
+import { FaRegEye, FaRegEyeSlash, FaRegTrashAlt } from "react-icons/fa";
+import { useState, useEffect } from "react";
+import styles from "./accountRegisterTable.module.css";
+
+type ShowPassConfigsType = {
+  [key: number]: boolean;
+};
+
+type StudentRegisterTableProps = {
+  accounts: StudentAccountRegisterType[];
+  setAccounts: (accounts: StudentAccountRegisterType[]) => void;
+};
+
+export const StudentAccountRegisterTable = ({
+  accounts,
+  setAccounts,
+}: StudentRegisterTableProps) => {
+  const [show, setShow] = useState<ShowPassConfigsType>({});
+
+  useEffect(() => {
+    setShow(() => {
+      const next: ShowPassConfigsType = {};
+      accounts.forEach((_, index) => {
+        next[index] = false;
+      });
+      return next;
+    });
+  }, [accounts]);
+
+  const toggleConfig = (targetId: number) => {
+    setShow((prev) => ({
+      ...prev,
+      [targetId]: !prev[targetId],
+    }));
+  };
+
+  return (
+    <div className={styles.accountTableContainer}>
+      <h3 className={styles.sectionName}>登録プレビュー</h3>
+
+      <div className={styles.tableScroll}>
+        <table className={styles.accountTable}>
+          <thead>
+            <tr>
+              <th>名前</th>
+              <th>学年</th>
+              <th>メールアドレス</th>
+              <th>パスワード</th>
+              <th>入学時期</th>
+              <th>卒業見込み</th>
+              <th className={styles.actionsHead}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((account, index) => {
+              return (
+                <tr key={index} tabIndex={0}>
+                  <td>{account.name}</td>
+                  <td>{account.grade}</td>
+                  <td>{account.email}</td>
+                  <td>
+                    <div className={styles.passwordCol}>
+                      {show[index] ? (
+                        <>
+                          <span>{account.password}</span>
+                          <button
+                            type="button"
+                            className={styles.actionButton}
+                            onClick={() => toggleConfig(index)}
+                          >
+                            <FaRegEye />
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <span>{"********"}</span>
+                          <button
+                            type="button"
+                            className={styles.actionButton}
+                            onClick={() => toggleConfig(index)}
+                          >
+                            <FaRegEyeSlash />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                  <td>{account.entryDate}</td>
+                  <td>{account.graduateDate}</td>
+                  <td className={styles.actionsCell}>
+                    <div className={styles.actionsInner}>
+                      <button
+                        type="button"
+                        className={styles.actionButton}
+                        title="編集"
+                      >
+                        <MdEdit color="rgb(56, 94, 164)" />
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.actionButton}
+                        title="削除"
+                      >
+                        <FaRegTrashAlt color="#fa5959" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/management/components/menuDrawer/menuDrawer.module.css
+++ b/frontend/src/features/management/components/menuDrawer/menuDrawer.module.css
@@ -3,6 +3,7 @@
   width: 250px;
   flex-shrink: 0;
   height: 100%;
+  min-height: 0;
   flex-direction: column;
   align-items: center;
   padding: 0.5rem;
@@ -10,6 +11,7 @@
   box-sizing: border-box;
   background-color: rgb(230, 240, 255);
   z-index: 20;
+  height: calc(100vh - 64px);
 }
 
 .closeDrawer {
@@ -90,7 +92,7 @@
   cursor: pointer;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .drawer {
     position: fixed;
     top: 0;

--- a/frontend/src/features/management/components/menuDrawer/menuDrawer.tsx
+++ b/frontend/src/features/management/components/menuDrawer/menuDrawer.tsx
@@ -37,7 +37,7 @@ const MENU_ITEMS = [
     icon: <FaBell />,
   },
   {
-    path: paths.app.management.account.list.path,
+    path: paths.app.management.account.root.path,
     name: "アカウント管理",
     icon: <MdManageAccounts />,
   },

--- a/frontend/src/features/management/style/accountRegister.module.css
+++ b/frontend/src/features/management/style/accountRegister.module.css
@@ -85,17 +85,33 @@
 .contents {
   display: flex;
   flex-direction: column;
+  align-items: center;
   height: 100%;
   width: 100%;
   min-height: 0;
   min-width: 0;
   gap: 1rem;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
 }
 
 .formContainer {
   display: flex;
   height: auto;
   width: 100%;
+}
+
+.button {
+  height: 38px;
+  width: 50%;
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  background-color: rgb(56, 94, 164);
+  color: #fff;
+  cursor: pointer;
+  flex: 0 0 auto;
+  white-space: nowrap;
 }

--- a/frontend/src/features/management/style/accountRegister.module.css
+++ b/frontend/src/features/management/style/accountRegister.module.css
@@ -1,0 +1,85 @@
+.contents {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  min-height: 0;
+  min-width: 0;
+  gap: 1rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.contents hr {
+  width: 100%;
+  height: 0;
+  border: 0;
+  border-top: 1px solid #b7b7b7;
+  background: transparent;
+}
+
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.sectionName {
+  font-weight: 600;
+}
+
+.toggleTab {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  width: 200px;
+  padding: 8px;
+  box-sizing: border-box;
+  background-color: #f1f5f9;
+  border-radius: 8px;
+}
+
+.toggleTab::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 8px;
+  width: calc(50% - 8px);
+  background-color: white;
+  border-radius: 6px;
+  transition: transform 0.3s ease;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  z-index: 0;
+}
+
+.toggleTab[data-active="teacher"]::before {
+  transform: translateX(calc(100%));
+}
+
+.toggleTab button {
+  border: none;
+  background: none;
+  font-size: 1rem;
+  font-weight: 500;
+  flex: 1;
+  z-index: 1;
+  cursor: pointer;
+  color: #94a3b8;
+  transition: color 0.3s ease;
+}
+
+.toggleTab:not([data-active="teacher"]) button:first-child {
+  color: rgb(100, 130, 215);
+  font-weight: bold;
+}
+
+.toggleTab[data-active="teacher"] button:last-child {
+  color: rgb(100, 130, 215);
+  font-weight: bold;
+}

--- a/frontend/src/features/management/style/accountRegister.module.css
+++ b/frontend/src/features/management/style/accountRegister.module.css
@@ -1,4 +1,4 @@
-.contents {
+.contentsContainer {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -6,11 +6,9 @@
   min-height: 0;
   min-width: 0;
   gap: 1rem;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
-.contents hr {
+.contentsContainer hr {
   width: 100%;
   height: 0;
   border: 0;
@@ -82,4 +80,22 @@
 .toggleTab[data-active="teacher"] button:last-child {
   color: rgb(100, 130, 215);
   font-weight: bold;
+}
+
+.contents {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  min-height: 0;
+  min-width: 0;
+  gap: 1rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.formContainer {
+  display: flex;
+  height: auto;
+  width: 100%;
 }

--- a/frontend/src/features/management/types/account.ts
+++ b/frontend/src/features/management/types/account.ts
@@ -28,3 +28,20 @@ export type StudentAccountEditType = AccountEditType & {
 export type TeacherAccountEditType = AccountEditType & {
   authority: 0 | 1;
 };
+
+export type StudentAccountRegisterType = {
+  name: string;
+  grade: number;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  entryDate: string;
+  graduateDate: string;
+};
+
+export type TeacherAccountRegisterType = {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};

--- a/frontend/src/hooks/useBlockNavigation.ts
+++ b/frontend/src/hooks/useBlockNavigation.ts
@@ -1,0 +1,24 @@
+import { useBlocker } from "react-router";
+import { useEffect } from "react";
+
+export const useBlockNavigation = (isDirty: boolean) => {
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      // isDirtyがtrue、かつ現在のパスと次のパスが違う場合にブロック
+      isDirty && currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  useEffect(() => {
+    // ブロック状態になったらブラウザ標準のconfirmを出す
+    if (blocker.state === "blocked") {
+      const confirmLeave = window.confirm(
+        "入力内容が保存されていません。移動しますか？",
+      );
+      if (confirmLeave) {
+        blocker.proceed(); // 移動する
+      } else {
+        blocker.reset(); // 移動キャンセル
+      }
+    }
+  }, [blocker]);
+};


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
https://github.com/CERS-Projects/Tuna/issues/132

### イシュー番号(自動クローズ用)

close #132 

## やったこと

<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？
- 教師機能である手入力アカウント登録機能のUIを実装
- 生徒・教師でフォームとテーブルを切り替えられるようにした

## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
- 登録APIの実装

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
- 無し

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
- 無し

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？
- 画面幅が狭くなった時に隠れてしまう部分がないかをチェックした
- 登録したデータが作成完了ボタンによって送信されることを確認した
- 編集や削除時の動作確認
- 

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」
- なし

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」
- なし

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
