### PR TITLE
アカウント編集画面(教師)のパスパラメータをユーザIDにする: frontend 

### DIFF
--- a/frontend/src/app/routes/app/management/account/accountEdit.tsx
+++ b/frontend/src/app/routes/app/management/account/accountEdit.tsx
@@ -22,15 +22,14 @@ const isTeacherAccount = (
 const AccountEdit = () => {
   const navigate = useNavigate();
   const { userId } = useParams();
+  const parsedUserId = Number(userId) || 0;
 
   useEffect(() => {
-    const parsed = Number(userId);
-    if (!userId || Number.isNaN(parsed) || parsed <= 0) {
+    if (!userId || Number.isFinite(parsedUserId) || parsedUserId <= 0) {
       navigate(paths.app.management.account.list.path, { replace: true });
     }
-  }, [userId, navigate]);
+  }, [userId, navigate, parsedUserId]);
 
-  const parsedUserId = Number(userId) || 0;
   const { data: account, isFetching, isError } = useAccount(parsedUserId);
 
   const handleDelete = async () => {

--- a/frontend/src/app/routes/app/management/account/accountEdit.tsx
+++ b/frontend/src/app/routes/app/management/account/accountEdit.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import { useAccount } from "@/features/management/hooks/useAccount";
 import { BackPage } from "@/features/management/components/backPage/backPage";
 import {
@@ -13,29 +13,25 @@ import {
 import styles from "@/features/management/style/accountEdit.module.css";
 import { paths } from "@/config/paths";
 
-type LocationState = {
-  userId?: number;
-};
-
 const isTeacherAccount = (
-  account: StudentAccountEditType | TeacherAccountEditType
+  account: StudentAccountEditType | TeacherAccountEditType,
 ): account is TeacherAccountEditType => {
   return "authority" in account;
 };
 
 const AccountEdit = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-
-  const state = (location.state as LocationState | null) ?? null;
-  const userId = Number(state?.userId);
+  const { userId } = useParams();
 
   useEffect(() => {
-    if (!userId)
+    const parsed = Number(userId);
+    if (!userId || Number.isNaN(parsed) || parsed <= 0) {
       navigate(paths.app.management.account.list.path, { replace: true });
+    }
   }, [userId, navigate]);
 
-  const { data: account, isFetching, isError } = useAccount(userId);
+  const parsedUserId = Number(userId) || 0;
+  const { data: account, isFetching, isError } = useAccount(parsedUserId);
 
   const handleDelete = async () => {
     if (!userId) {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -167,9 +167,8 @@ export const paths = {
           getHref: () => "/manager/account/list",
         },
         edit: {
-          path: "/manager/account/edit/:showUserId",
-          getHref: (showUserId: string) =>
-            `/manager/account/edit/${showUserId}`,
+          path: "/manager/account/edit/:userId",
+          getHref: (userId: number) => `/manager/account/edit/${userId}`,
         },
         new: {
           path: "/manager/account/new",

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -168,7 +168,8 @@ export const paths = {
         },
         edit: {
           path: "/manager/account/edit/:userId",
-          getHref: (userId: number) => `/manager/account/edit/${userId}`,
+          getHref: (userId: number | string) =>
+            `/manager/account/edit/${userId}`,
         },
         new: {
           path: "/manager/account/new",

--- a/frontend/src/features/management/components/accountTable/accountTable.tsx
+++ b/frontend/src/features/management/components/accountTable/accountTable.tsx
@@ -10,11 +10,8 @@ type Props = {
 export const AccountTable = ({ accounts }: Props) => {
   const navigate = useNavigate();
 
-  const handleUserNavigate = (userId: number, showUserId: string) => {
-    navigate(paths.app.management.account.edit.getHref(showUserId), {
-      relative: "route",
-      state: { userId: userId },
-    });
+  const handleUserNavigate = (userId: number) => {
+    navigate(paths.app.management.account.edit.getHref(userId));
   };
 
   return (
@@ -36,13 +33,11 @@ export const AccountTable = ({ accounts }: Props) => {
                 <tr
                   key={account.userId}
                   tabIndex={0}
-                  onClick={() =>
-                    handleUserNavigate(account.userId, account.showUserId)
-                  }
+                  onClick={() => handleUserNavigate(account.userId)}
                   onKeyDown={(e) => {
                     if (e.key !== "Enter") return;
                     e.preventDefault();
-                    handleUserNavigate(account.userId, account.showUserId);
+                    handleUserNavigate(account.userId);
                   }}
                 >
                   <td>{account.showUserId}</td>

--- a/frontend/src/features/management/hooks/useAccount.ts
+++ b/frontend/src/features/management/hooks/useAccount.ts
@@ -31,7 +31,7 @@ export const useAccount = (userId: number) => {
     StudentAccountEditType | TeacherAccountEditType
   >({
     queryKey: ["account", userId],
-    enabled: false,
+    enabled: userId > 0,
     queryFn: async (): Promise<
       StudentAccountEditType | TeacherAccountEditType
     > => {


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
https://github.com/CERS-Projects/Tuna/issues/150

### イシュー番号(自動クローズ用)

close #150 

## やったこと

<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？
- パスパラメータにユーザIDを含めて、アカウント編集画面に直接アクセスできるようにした
- 数値以外をパスに含めると、一覧画面にリダイレクトするようにした

## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
- API接続の実装

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
- アカウント一覧画面から編集画面への遷移ではなくても、アカウント編集画面に遷移できるようになった

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
- なし

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？
- リダイレクト、編集画面への直接アクセスができるかを試し、成功した

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」
- なし

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」
- なし

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- なし
