### PR TITLE
生徒及び教師アカウントの単体取得の実装とCSVによるアカウント登録に係るバリデーションをutilファイルを呼び出す形式に変更：backend

### DIFF
--- a/backend/src/main/java/com/example/backend/accounts/controller/StudentController.java
+++ b/backend/src/main/java/com/example/backend/accounts/controller/StudentController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ import com.example.backend.accounts.dto.StudentCreateRequest;
 import com.example.backend.accounts.dto.StudentInformationResponse;
 import com.example.backend.accounts.model.UserEntity;
 import com.example.backend.accounts.service.StudentService;
+import com.example.backend.utils.fileUtil.validation.DocumentFileValidation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,16 +31,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StudentController {
 
-    /* StudentServiceの依存注入 */
     private final StudentService studentService;
 
-    
-    @GetMapping("/student/information")
+    private final DocumentFileValidation documentFileValidation;
+
+    /* 特定のschoolIdに紐づく生徒情報を全件取得する */
+    @GetMapping("/student/all/information")
     public ResponseEntity<List<StudentInformationResponse>> getStudentInformation(@Valid @ModelAttribute GetFindAllStudentAccountRequest dto){
         List<StudentInformationResponse> responses = studentService.findStudentInformationResponses(dto);
         return ResponseEntity.ok(responses);
     }
 
+    /* 特定のuserIdに紐づく生徒情報を1件取得する */
+    @GetMapping("/student/{studentId}/information")
+    public ResponseEntity<StudentInformationResponse> getOneStudentInformation(@PathVariable final Integer studentId){
+        StudentInformationResponse response = studentService.findOneStudentInformationResponse(studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    /* 生徒アカウントを作成する */
     @PostMapping("/student")
     public ResponseEntity<Void> createStudent(@RequestBody @Valid List<StudentCreateRequest> dto){
          /* 基本ユーザ情報を登録する */
@@ -54,39 +65,18 @@ public class StudentController {
      */
     @PostMapping("/student/csv-file")
     public ResponseEntity<String> createStudentByFile(@RequestPart("file") MultipartFile uploadCsvFile, @RequestParam("refId") final Integer schoolId)throws IOException{
-        ResponseEntity<String> validationResult = fileValidation(uploadCsvFile);
-        studentService.createStudentByFile(uploadCsvFile, schoolId);
-        if(validationResult != null){
-            return validationResult;
-        } else {
-            return ResponseEntity.ok().body("生徒アカウントの一括登録が完了しました。");
+        boolean validationResult = documentFileValidation.isValidDocumentFile(uploadCsvFile);
+        if(!validationResult){
+            return ResponseEntity.badRequest().body("アカウント生成に失敗しました。");
         }
+        studentService.createStudentByFile(uploadCsvFile, schoolId);
+        return ResponseEntity.ok().body("アカウントを正常に生成しました。");
     }
 
+    /* 生徒情報を変更する */
     @PostMapping("/student/modify")
     public ResponseEntity<Void> modifyStudentAccount(@RequestBody @Valid ModifyStudentAccountRequest dto){
         studentService.modifyStudentAccount(dto);
         return ResponseEntity.ok().build();
-    }
-
-
-    /* Validationパッケージに移動予定　D5,まっつん */
-    public ResponseEntity<String> fileValidation(MultipartFile uploadFile){
-        if(uploadFile.isEmpty()){
-            return ResponseEntity.badRequest().body("ファイルが選択されていません。CSVファイルをアップロードしてください。");
-        }
-
-        String contentType = uploadFile.getContentType();
-        if(contentType == null || !contentType.equals("text/csv")){
-            return ResponseEntity.badRequest().body("ファイル形式が不正です。CSVファイルをアップロードしてください。");
-        }
-
-        final long MAX_CSV_SIZE = 1 * 1024 * 1024; // 1MB
-        if(uploadFile.getSize() > MAX_CSV_SIZE){
-            throw new IllegalArgumentException("ファイルサイズが大きすぎます。1MB以下のファイルをアップロードしてください。");
-        }
-
-        ResponseEntity<String> successValidation = null;
-        return successValidation;
     }
 }

--- a/backend/src/main/java/com/example/backend/accounts/controller/TeacherController.java
+++ b/backend/src/main/java/com/example/backend/accounts/controller/TeacherController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,10 +32,16 @@ public class TeacherController {
     /* AdminUserServiceの依存注入 */
     private final AdminUserService adminUserService;
 
-    @GetMapping("/teacher/information")
+    @GetMapping("/teacher/all/information")
     public ResponseEntity<List<TeacherInformationResponse>> getTeacherInformation(@Valid @ModelAttribute GetFindAllTeacherAccountRequest dto){
         List<TeacherInformationResponse> responses = teacherService.findTeacherInformationResponses(dto);
         return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/teacher/{teacherId}/information")
+    public ResponseEntity<TeacherInformationResponse> getOneTeacherInformation(@Valid @ModelAttribute @PathVariable final Integer teacherId){
+        TeacherInformationResponse response = teacherService.findOneTeacherInformationResponse(teacherId);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/teacher")

--- a/backend/src/main/java/com/example/backend/accounts/repository/StudentRepository.java
+++ b/backend/src/main/java/com/example/backend/accounts/repository/StudentRepository.java
@@ -47,6 +47,21 @@ public interface StudentRepository extends JpaRepository<StudentEntity, Integer>
     List<StudentInformationResponse> findAllStudentInformation(@Param("schoolId") Integer schoolId);
 
     @Query ("""
+            SELECT new com.example.backend.accounts.dto.StudentInformationResponse(
+                user.userId,
+                user.showUserId, 
+                user.name, 
+                student.grade, 
+                user.accountsStopFlag)
+            FROM UserEntity AS user
+            INNER JOIN 
+            StudentEntity AS student
+                ON user.userId = student.userId
+            WHERE user.userId = :studentId
+            """)
+    StudentInformationResponse findOneStudentInformation(@Param("studentId") final Integer studentId);
+
+    @Query ("""
             SELECT userId FROM UserEntity 
             WHERE school.schoolId = :schoolId
             """)

--- a/backend/src/main/java/com/example/backend/accounts/repository/TeacherRepository.java
+++ b/backend/src/main/java/com/example/backend/accounts/repository/TeacherRepository.java
@@ -27,6 +27,21 @@ public interface TeacherRepository extends JpaRepository<TeacherEntity, Integer>
             """)
     List<TeacherInformationResponse> findAllTeacherInformation(@Param("schoolId") Integer schoolId);
 
+    @Query("""
+            SELECT new com.example.backend.accounts.dto.TeacherInformationResponse(
+                user.userId,
+                user.showUserId,
+                user.name,
+                teacher.authorityFlag,
+                user.accountsStopFlag)
+            FROM UserEntity AS user
+            INNER JOIN
+            TeacherEntity AS teacher
+                ON user.userId = teacher.userId
+            WHERE user.userId = :teacherId
+            """)
+    TeacherInformationResponse findOneTeacherInformation(@Param("teacherId") Integer teacherId);
+
     @Modifying
     @Transactional
     @Query("""

--- a/backend/src/main/java/com/example/backend/accounts/service/StudentService.java
+++ b/backend/src/main/java/com/example/backend/accounts/service/StudentService.java
@@ -20,4 +20,5 @@ public interface StudentService {
     List<GetUserResponse> findAllGroups(GetUserBySchoolIdRequest dto);
     List<StudentInformationResponse> findStudentInformationResponses(GetFindAllStudentAccountRequest dto);
     void modifyStudentAccount(ModifyStudentAccountRequest dto);
+    StudentInformationResponse findOneStudentInformationResponse(final Integer studentId);
 }

--- a/backend/src/main/java/com/example/backend/accounts/service/TeacherService.java
+++ b/backend/src/main/java/com/example/backend/accounts/service/TeacherService.java
@@ -18,4 +18,5 @@ public interface TeacherService {
     UserEntity createTeacher(TeacherCreateRequestInApp dto);
     List<TeacherInformationResponse> findTeacherInformationResponses(GetFindAllTeacherAccountRequest dto);
     void modifyTeacherAccountByUserId(ModifyTeacherAccountRequest dto);
+    TeacherInformationResponse findOneTeacherInformationResponse(final Integer teacherId);
 }

--- a/backend/src/main/java/com/example/backend/accounts/service/impl/StudentServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/accounts/service/impl/StudentServiceImpl.java
@@ -130,6 +130,13 @@ public class StudentServiceImpl implements StudentService{
         studentRepository.saveAll(studentEntities);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public StudentInformationResponse findOneStudentInformationResponse(final Integer studentId){
+        StudentInformationResponse response = studentRepository.findOneStudentInformation(studentId);
+        return response;
+    }
+
     /*
      * CSVファイルから一括で生徒アカウントを登録する機能
      * InputStream inputStream = csvFile.getInputStream(): アップロードされたCSVファイルの内容を読み取るためのストリーム

--- a/backend/src/main/java/com/example/backend/accounts/service/impl/TeacherServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/accounts/service/impl/TeacherServiceImpl.java
@@ -41,6 +41,7 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
 
     private final SchoolRepository schoolRepository;
 
+    /* schoolIdに紐づく教師情報を全件取得する */
     @Override
     @Transactional(readOnly = true)
     public List<TeacherInformationResponse> findTeacherInformationResponses(GetFindAllTeacherAccountRequest dto){
@@ -48,10 +49,16 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
         return teacherRepository.findAllTeacherInformation(SCHOOL_ID);
     }
 
+    /* 特定のuserIdに紐づく教師情報を1件取得する */
+    @Override
+    @Transactional(readOnly = true)
+    public TeacherInformationResponse findOneTeacherInformationResponse(final Integer teacherId){
+        TeacherInformationResponse response = teacherRepository.findOneTeacherInformation(teacherId);
+        return response;
+    }
 
-    /*
-     *　学校登録に付随する、アカウント登録に係る基本情報をMySQLに登録する機能
-     */
+
+    /* 学校登録に付随する、アカウント登録に係る基本情報をMySQLに登録する機能 */
     @Override
     @Transactional
     public UserEntity createTeacher(TeacherCreateRequestOutSideApp dto, Integer schoolId){
@@ -69,9 +76,7 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
         return savedTeacherEntity;
     }
 
-    /*
-     *　ウェブアプリ内からの教師アカウント作成機能を提供する
-     */
+    /* ウェブアプリ内からの教師アカウント作成機能を提供する */
     @Override
     @Transactional
     public UserEntity createTeacher(TeacherCreateRequestInApp dto){
@@ -89,9 +94,7 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
     }
 
 
-    /* 
-     *  管理者権限あり状態を登録する機能
-     */
+    /* 管理者権限あり状態を登録する機能 */
     @Override
     @Transactional
     public void authorityGrant(UserEntity newTeacher){
@@ -104,9 +107,7 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
         teacherRepository.save(newAdmin);
     }
 
-    /*
-     * 権限フラグをなしで設定する
-     */
+    /* 権限フラグをなしで設定する */
     @Override
     @Transactional
     public void authorityNotGrant(UserEntity newTeacher){
@@ -118,6 +119,7 @@ public class TeacherServiceImpl implements TeacherService, AdminUserService{
         teacherRepository.save(newAdmin);
     }
 
+    /* 教師アカウント情報を更新する機能 */
     @Override
     @Transactional
     public void modifyTeacherAccountByUserId(ModifyTeacherAccountRequest dto){


### PR DESCRIPTION
…ionをStudentControllerのCSVバリデーションに適用 #153

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー
#153
<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
#153
### イシュー番号(自動クローズ用)

close #153

## やったこと

<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？
- 生徒アカウントの単体取得
- 教師アカウントの単体取得
- CSVによるアカウント取得において、ファイルバリデーションをutilsから呼び出す形式に変更
## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
- とくに無し
## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
- アカウント詳細で指定したユーザの詳細情報をURL直打ちでも対応できるようになる
## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
- とくに無し
## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？
PostmanでAPIをたたき動作を確認し、動作を確認しました
## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」
- とくに無し
## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」
- とくに無し
## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
