### PR TITLE
投稿フィルタリング画面の実装: frontend

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -166,15 +166,11 @@ const createAppRouter = (queryClient: QueryClient) => {
           () => import("./routes/app/profile/setting/settingMenu"),
         ),
         route(
-          paths.app.profile.edit.path,
-          () => import("./routes/app/profile/edit/editProfile"),
-        ),
-        route(
-          paths.app.profile.edit.editPassword.path,
+          paths.app.profile.settingMenu.editPassword.path,
           () => import("./routes/app/profile/edit/editPassword"),
         ),
         route(
-          paths.app.profile.edit.editFilter.path,
+          paths.app.profile.settingMenu.editFilter.path,
           () => import("./routes/app/profile/edit/editFilter"),
         ),
       ],

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -173,6 +173,10 @@ const createAppRouter = (queryClient: QueryClient) => {
           paths.app.profile.edit.editPassword.path,
           () => import("./routes/app/profile/edit/editPassword"),
         ),
+        route(
+          paths.app.profile.edit.editFilter.path,
+          () => import("./routes/app/profile/edit/editFilter"),
+        ),
       ],
     },
 

--- a/frontend/src/app/routes/app/profile/edit/editFilter.tsx
+++ b/frontend/src/app/routes/app/profile/edit/editFilter.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import styles from "@/features/profile/styles/editFilter.module.css";
+
+type FilterWord = {
+  word: string;
+};
+
+const dummyFilterWords: FilterWord[] = [
+  { word: "test" },
+  { word: "test2" },
+  { word: "ああ" },
+];
+
+const EditFilter = () => {
+  const [filterWords, setFilterWords] =
+    useState<FilterWord[]>(dummyFilterWords);
+  const [inputWord, setInputWord] = useState<string>("");
+
+  const maxLength = 20;
+
+  const handleAddWord = () => {
+    const trimmedInput = inputWord.trim();
+    if (!trimmedInput) return;
+
+    const isDuplicate = filterWords.some((item) => item.word === trimmedInput);
+    if (isDuplicate) {
+      alert(`「${trimmedInput}」は既に追加されています。`);
+      return;
+    }
+    if (trimmedInput.length > maxLength) {
+      alert(`${maxLength}文字以内で入力してください。`);
+      return;
+    }
+
+    const newFilterWord: FilterWord = { word: trimmedInput };
+    setFilterWords([newFilterWord, ...filterWords]);
+    setInputWord("");
+  };
+
+  const handleRemoveWord = (indexToRemove: number) => {
+    const newWords = filterWords.filter((_, index) => index !== indexToRemove);
+    setFilterWords(newWords);
+  };
+
+  return (
+    <div className={styles.background}>
+      <div className={styles.layoutFrame}>
+        <div className={styles.card}>
+          <div className={styles.header}>
+            <h2 className={styles.title}>フィルタリング設定</h2>
+            <p className={styles.description}>
+              特定の単語を含む投稿をタイムラインで非表示にします
+            </p>
+          </div>
+
+          <div className={styles.inputGroup}>
+            <div className={styles.inputWrapper}>
+              <div className={styles.labelContainer}>
+                <label htmlFor="filterWord" className={styles.label}>
+                  新しいワードを追加
+                </label>
+                <span
+                  className={`${styles.charCount} ${
+                    inputWord.length >= maxLength ? styles.charCountLimit : ""
+                  }`}
+                >
+                  {inputWord.length} / {maxLength}
+                </span>
+              </div>
+              <input
+                id="filterWord"
+                type="text"
+                className={styles.input}
+                placeholder="例: ネタバレ"
+                value={inputWord}
+                maxLength={20}
+                onChange={(e) => setInputWord(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAddWord();
+                }}
+              />
+            </div>
+            <button className={styles.addButton} onClick={handleAddWord}>
+              追加する
+            </button>
+          </div>
+
+          <div className={styles.listContainer}>
+            <div className={styles.listHeader}>
+              登録済みのワード ({filterWords.length})
+            </div>
+            <ul className={styles.wordList}>
+              {filterWords.map((wordObj, index) => (
+                <li key={index} className={styles.wordItem}>
+                  <span className={styles.wordText}>{wordObj.word}</span>
+                  <button
+                    className={styles.deleteButton}
+                    onClick={() => handleRemoveWord(index)}
+                    aria-label="削除"
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+              {filterWords.length === 0 && (
+                <li className={styles.emptyState}>
+                  登録されているワードはありません
+                </li>
+              )}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditFilter;

--- a/frontend/src/app/routes/app/profile/edit/editFilter.tsx
+++ b/frontend/src/app/routes/app/profile/edit/editFilter.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import styles from "@/features/profile/styles/editFilter.module.css";
 
 type FilterWord = {
@@ -15,31 +15,42 @@ const EditFilter = () => {
   const [filterWords, setFilterWords] =
     useState<FilterWord[]>(dummyFilterWords);
   const [inputWord, setInputWord] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
 
   const maxLength = 20;
 
+  const isInvalidInput =
+    inputWord.trim().length === 0 || inputWord.length > maxLength;
+
   const handleAddWord = () => {
     const trimmedInput = inputWord.trim();
+
     if (!trimmedInput) return;
 
     const isDuplicate = filterWords.some((item) => item.word === trimmedInput);
     if (isDuplicate) {
-      alert(`「${trimmedInput}」は既に追加されています。`);
-      return;
-    }
-    if (trimmedInput.length > maxLength) {
-      alert(`${maxLength}文字以内で入力してください。`);
+      setErrorMessage(`「${trimmedInput}」は既に追加されています`);
       return;
     }
 
     const newFilterWord: FilterWord = { word: trimmedInput };
     setFilterWords([newFilterWord, ...filterWords]);
+
     setInputWord("");
+    setErrorMessage("");
   };
 
-  const handleRemoveWord = (indexToRemove: number) => {
-    const newWords = filterWords.filter((_, index) => index !== indexToRemove);
+  const handleRemoveWord = (wordToRemove: string) => {
+    const newWords = filterWords.filter((item) => item.word !== wordToRemove);
     setFilterWords(newWords);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !isInvalidInput) {
+      e.preventDefault();
+      handleAddWord();
+    }
   };
 
   return (
@@ -61,7 +72,7 @@ const EditFilter = () => {
                 </label>
                 <span
                   className={`${styles.charCount} ${
-                    inputWord.length >= maxLength ? styles.charCountLimit : ""
+                    inputWord.length > maxLength ? styles.charCountLimit : ""
                   }`}
                 >
                   {inputWord.length} / {maxLength}
@@ -70,17 +81,34 @@ const EditFilter = () => {
               <input
                 id="filterWord"
                 type="text"
-                className={styles.input}
+                className={`${styles.input} ${errorMessage ? styles.inputError : ""}`}
                 placeholder="例: ネタバレ"
                 value={inputWord}
-                maxLength={20}
-                onChange={(e) => setInputWord(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAddWord();
+                onChange={(e) => {
+                  setInputWord(e.target.value);
+                  if (errorMessage) setErrorMessage("");
                 }}
+                onKeyDown={handleKeyDown}
               />
+              {errorMessage && (
+                <p
+                  className={styles.errorMessage}
+                  style={{ color: "red", fontSize: "0.8rem", marginTop: "4px" }}
+                >
+                  {errorMessage}
+                </p>
+              )}
             </div>
-            <button className={styles.addButton} onClick={handleAddWord}>
+            <button
+              type="button"
+              className={styles.addButton}
+              onClick={handleAddWord}
+              disabled={isInvalidInput}
+              style={{
+                opacity: isInvalidInput ? 0.5 : 1,
+                cursor: isInvalidInput ? "not-allowed" : "pointer",
+              }}
+            >
               追加する
             </button>
           </div>
@@ -90,13 +118,14 @@ const EditFilter = () => {
               登録済みのワード ({filterWords.length})
             </div>
             <ul className={styles.wordList}>
-              {filterWords.map((wordObj, index) => (
-                <li key={index} className={styles.wordItem}>
+              {filterWords.map((wordObj) => (
+                <li key={wordObj.word} className={styles.wordItem}>
                   <span className={styles.wordText}>{wordObj.word}</span>
                   <button
+                    type="button"
                     className={styles.deleteButton}
-                    onClick={() => handleRemoveWord(index)}
-                    aria-label="削除"
+                    onClick={() => handleRemoveWord(wordObj.word)}
+                    aria-label={`${wordObj.word}を削除`}
                   >
                     ✕
                   </button>

--- a/frontend/src/app/routes/app/profile/setting/settingMenu.tsx
+++ b/frontend/src/app/routes/app/profile/setting/settingMenu.tsx
@@ -9,13 +9,13 @@ import { paths } from "@/config/paths";
 const MenuItems: MenuItemType[] = [
   {
     menuName: "パスワード更新",
-    menuPath: paths.app.profile.edit.editPassword.getHref(),
+    menuPath: paths.app.profile.settingMenu.editPassword.getHref(),
     menuIcon: <RiLockPasswordFill />,
     menuLabel: "パスワードの変更を行います",
   },
   {
     menuName: "フィルタリング設定",
-    menuPath: paths.app.profile.edit.editFilter.getHref(),
+    menuPath: paths.app.profile.settingMenu.editFilter.getHref(),
     menuIcon: <IoFilterOutline />,
     menuLabel: "フィルタリングの設定を行います",
   },

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -142,6 +142,10 @@ export const paths = {
           path: "/app/profile/edit/editPassword",
           getHref: () => "/app/profile/edit/editPassword",
         },
+        editFilter: {
+          path: "/app/profile/edit/editFilter",
+          getHref: () => "/app/profile/edit/editFilter",
+        },
       },
     },
     test: {

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -134,17 +134,13 @@ export const paths = {
       settingMenu: {
         path: "/app/profile/settingMenu",
         getHref: () => "/app/profile/settingMenu",
-      },
-      edit: {
-        path: "/app/profile/edit",
-        getHref: () => "/app/profile/edit",
         editPassword: {
-          path: "/app/profile/edit/editPassword",
-          getHref: () => "/app/profile/edit/editPassword",
+          path: "/app/profile/settingMenu/editPassword",
+          getHref: () => "/app/profile/settingMenu/editPassword",
         },
         editFilter: {
-          path: "/app/profile/edit/editFilter",
-          getHref: () => "/app/profile/edit/editFilter",
+          path: "/app/profile/settingMenu/editFilter",
+          getHref: () => "/app/profile/settingMenu/editFilter",
         },
       },
     },

--- a/frontend/src/features/profile/styles/editFilter.module.css
+++ b/frontend/src/features/profile/styles/editFilter.module.css
@@ -1,0 +1,239 @@
+.background {
+  background-color: #f1f5f9;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+}
+
+.layoutFrame {
+  width: 100%;
+  max-width: 1500px;
+  height: auto;
+  padding: 0 40px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  background-color: #ffffff;
+  width: 100%;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  padding: 32px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+}
+
+.header {
+  margin-bottom: 24px;
+  border-bottom: 1px solid #bfdfff;
+  padding-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 700;
+  color: rgb(50, 85, 150);
+  margin: 0;
+}
+
+.description {
+  font-size: 13px;
+  margin-top: 6px;
+  line-height: 1.5;
+}
+
+.inputGroup {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-shrink: 0;
+}
+
+.inputWrapper {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 0;
+  display: block;
+}
+
+.labelContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.charCount {
+  font-size: 12px;
+  color: #94a3b8;
+  font-feature-settings: "tnum";
+  transition: color 0.2s ease;
+}
+
+.charCountLimit {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.input {
+  padding: 10px 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 15px;
+  outline: none;
+  background-color: #f8fafc;
+}
+
+.input:focus {
+  border-color: rgb(50, 85, 150);
+  background-color: #ffffff;
+  box-shadow: 0 0 0 3px rgba(50, 85, 150, 0.15);
+}
+
+.addButton {
+  background-color: rgb(50, 85, 150);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0 20px;
+  height: 42px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.addButton:hover {
+  opacity: 0.9;
+}
+
+.listContainer {
+  margin-top: 16px;
+  border-top: 1px solid #bfdfff;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 0;
+}
+
+.listHeader {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 10px;
+  flex-shrink: 0;
+}
+
+.wordList {
+  list-style: none;
+  height: 300px;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 transparent;
+  padding-right: 4px;
+}
+
+.wordList::-webkit-scrollbar {
+  width: 6px;
+}
+.wordList::-webkit-scrollbar-track {
+  background: transparent;
+}
+.wordList::-webkit-scrollbar-thumb {
+  background-color: #cbd5e1;
+  border-radius: 10px;
+}
+
+.wordItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 8px;
+  border-bottom: 1px solid #bfdfff;
+}
+
+.wordItem:last-child {
+  border-bottom: none;
+}
+
+.emptyState {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  color: #94a3b8;
+  font-size: 14px;
+}
+
+.wordText {
+  font-size: 15px;
+  font-weight: 500;
+  word-break: break-all;
+  margin-right: 12px;
+}
+
+.deleteButton {
+  background-color: #ffffff;
+  border: 1px solid rgb(50, 85, 150);
+  color: rgb(50, 85, 150);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.deleteButton:hover {
+  background-color: #fee2e2;
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+@media (max-width: 600px) {
+  .layoutFrame {
+    padding: 0;
+    max-height: 100%;
+    height: 100%;
+  }
+
+  .card {
+    border-radius: 0;
+    padding: 20px;
+  }
+
+  .inputGroup {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .addButton {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク

### イシュー番号(自動クローズ用)

close #159 

## やったこと

<!-- このPRで何をしたのか？ -->

フィルタリング設定画面の実装をしました。

## やらないこと

<!-- このPRでやらないことは何か？ -->

データの送信はまだやってないです。ロジック組むときにやります。

## できるようになること（ユーザ目線）

ワードの入力と表への追加ができます。

## できなくなること（ユーザ目線）

ないです

## 動作確認

ワードの追加と重複/制限文字以上への対策の動作確認済みです。

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

ロジック組んだら投稿を扱っている画面への影響が出ます。

## テスト

<!-- テスト方法や結果 -->

ワードが追加できてるか見れれば大丈夫です。

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

コンポーネント分けしようと思ったけど処理ややこしくなりそうだったんで画面に処理直打ちしてます。
