### PR TITLE
ユーザが所属しているグループを取得する機能の実装：backend

### DIFF
--- a/backend/src/main/java/com/example/backend/group/repository/GroupMemberRepository.java
+++ b/backend/src/main/java/com/example/backend/group/repository/GroupMemberRepository.java
@@ -30,4 +30,11 @@ public interface GroupMemberRepository extends JpaRepository<GroupMemberEntity, 
                 AND mem.userId = :userId
             """)
     Long countDistinctByGroupIdIn(@Param("groupIds") List<Integer> groupIds, @Param("userId") Integer userId);
+
+    @Query("""
+            SELECT mem.groupId 
+            FROM GroupMemberEntity mem
+            WHERE mem.userId = :userId
+            """)
+    List<Integer> findJoinedGroupIdsByUserId(@Param("userId") Integer userId);
 }

--- a/backend/src/main/java/com/example/backend/utils/accountConfirm/GroupJoinByUserId.java
+++ b/backend/src/main/java/com/example/backend/utils/accountConfirm/GroupJoinByUserId.java
@@ -1,0 +1,21 @@
+package com.example.backend.utils.accountConfirm;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.example.backend.group.repository.GroupMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GroupJoinByUserId {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    List<Integer> getJoinedGroupIdsByUserId(Integer userId) {
+        return groupMemberRepository.findJoinedGroupIdsByUserId(userId);
+    }
+    
+}

--- a/backend/src/main/java/com/example/backend/utils/accountConfirm/GroupJoinByUserId.java
+++ b/backend/src/main/java/com/example/backend/utils/accountConfirm/GroupJoinByUserId.java
@@ -14,7 +14,7 @@ public class GroupJoinByUserId {
 
     private final GroupMemberRepository groupMemberRepository;
 
-    List<Integer> getJoinedGroupIdsByUserId(Integer userId) {
+    public List<Integer> getJoinedGroupIdsByUserId(Integer userId) {
         return groupMemberRepository.findJoinedGroupIdsByUserId(userId);
     }
     


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー
#177
<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
#177
### イシュー番号(自動クローズ用)

close #177

## やったこと
・ユーザが所属しているグループをすべて取得する機能を実装
<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？

## やらないこと
・なし
<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）
・なし
- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）
・なし
- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認
・できていませんが、productD5の方で動作確認を行います
- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？

## 影響範囲
・D5が開発している投稿機能
<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」

## テスト
・なし
<!-- テスト方法や結果 -->

- ない場合は「無し」

## 備考
もし意図した動作をしない場合は
utils\accountConfirm\GroupJoinByUserId.javaで呼び出ししていて、
group\repository\GroupMemberRepository.java\findJoinedGroupIdsbyUserIdメソッドで処理していますので、該当メソッドの@Queryアノテーション内のクエリを編集してください
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
