### PR TITLE
お知らせのレスポンスにグループの名前を追加：backend

### DIFF
--- a/backend/src/main/java/com/example/backend/group/repository/GroupRepository.java
+++ b/backend/src/main/java/com/example/backend/group/repository/GroupRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -68,4 +69,10 @@ public interface GroupRepository extends JpaRepository<GroupEntity, Integer> {
         List<GroupEntity> findBySchoolAndUserId(
                         @Param("userId") Integer userId,
                         @Param("schoolId") Integer schoolId);
+        
+         @Query("""
+            SELECT g.groupName FROM GroupEntity g
+            WHERE g.groupId = :groupId
+            """)
+        Optional<String> findGroupNameByGroupId(@Param("groupId") Integer groupId);
 }

--- a/backend/src/main/java/com/example/backend/group/repository/GroupRepository.java
+++ b/backend/src/main/java/com/example/backend/group/repository/GroupRepository.java
@@ -1,7 +1,6 @@
 package com.example.backend.group.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.backend.group.model.GroupEntity;
+import com.example.backend.notice.dto.GetGroupIdAndGroupNameRecord;
 
 public interface GroupRepository extends JpaRepository<GroupEntity, Integer> {
 
@@ -70,9 +70,10 @@ public interface GroupRepository extends JpaRepository<GroupEntity, Integer> {
                         @Param("userId") Integer userId,
                         @Param("schoolId") Integer schoolId);
         
-         @Query("""
-            SELECT g.groupName FROM GroupEntity g
-            WHERE g.groupId = :groupId
+        @Query("""
+            SELECT new com.example.backend.notice.dto.GetGroupIdAndGroupNameRecord(g.groupId, g.groupName) 
+            FROM GroupEntity g
+            WHERE g.groupId IN :groupId
             """)
-        Optional<String> findGroupNameByGroupId(@Param("groupId") Integer groupId);
+        List<GetGroupIdAndGroupNameRecord> findGroupNameByGroupIdIn(@Param("groupId") List<Integer> groupId);
 }

--- a/backend/src/main/java/com/example/backend/notice/dto/GetGroupIdAndGroupNameRecord.java
+++ b/backend/src/main/java/com/example/backend/notice/dto/GetGroupIdAndGroupNameRecord.java
@@ -1,0 +1,5 @@
+package com.example.backend.notice.dto;
+
+public record GetGroupIdAndGroupNameRecord(Integer groupId, String groupName) {
+
+}

--- a/backend/src/main/java/com/example/backend/notice/dto/NoticeListResponse.java
+++ b/backend/src/main/java/com/example/backend/notice/dto/NoticeListResponse.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 public class NoticeListResponse {
     private String noticeId;
     private Integer groupId;
+    private String groupName;
     private String title;
     private String content;
     private Date createdAt;

--- a/backend/src/main/java/com/example/backend/notice/helper/NoticeHelper.java
+++ b/backend/src/main/java/com/example/backend/notice/helper/NoticeHelper.java
@@ -3,11 +3,11 @@ package com.example.backend.notice.helper;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Map;
 
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Component;
 
-import com.example.backend.group.repository.GroupRepository;
 import com.example.backend.notice.dto.NoticeInsertRequest;
 import com.example.backend.notice.dto.NoticeListResponse;
 import com.example.backend.notice.dto.NoticeModifyRequest;
@@ -18,8 +18,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Component
 public class NoticeHelper {
-
-    private final GroupRepository groupRepository;
 
     public NoticeEntity toEntity(NoticeInsertRequest dto) {
         NoticeEntity entity = new NoticeEntity();
@@ -42,11 +40,11 @@ public class NoticeHelper {
         return entity;
     }
 
-    public NoticeListResponse toNoticeListResponse(NoticeEntity entity) {
+    public NoticeListResponse toNoticeListResponse(NoticeEntity entity, Map<Integer, String> groupIdToNameMap) {
         NoticeListResponse response = new NoticeListResponse();
         response.setNoticeId(entity.getNoticeId().toHexString());
         response.setGroupId(entity.getGroupId());
-        response.setGroupName(groupRepository.findGroupNameByGroupId(entity.getGroupId()).orElse("グループが存在しません。"));
+        response.setGroupName(groupIdToNameMap.getOrDefault(entity.getGroupId(), "グループが存在しません。"));
         response.setTitle(entity.getTitle());
         response.setContent(entity.getContent());
         response.setCreatedAt(entity.getCreatedAt());    

--- a/backend/src/main/java/com/example/backend/notice/helper/NoticeHelper.java
+++ b/backend/src/main/java/com/example/backend/notice/helper/NoticeHelper.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Component;
 
+import com.example.backend.group.repository.GroupRepository;
 import com.example.backend.notice.dto.NoticeInsertRequest;
 import com.example.backend.notice.dto.NoticeListResponse;
 import com.example.backend.notice.dto.NoticeModifyRequest;
@@ -17,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Component
 public class NoticeHelper {
+
+    private final GroupRepository groupRepository;
 
     public NoticeEntity toEntity(NoticeInsertRequest dto) {
         NoticeEntity entity = new NoticeEntity();
@@ -43,6 +46,7 @@ public class NoticeHelper {
         NoticeListResponse response = new NoticeListResponse();
         response.setNoticeId(entity.getNoticeId().toHexString());
         response.setGroupId(entity.getGroupId());
+        response.setGroupName(groupRepository.findGroupNameByGroupId(entity.getGroupId()).orElse("グループが存在しません。"));
         response.setTitle(entity.getTitle());
         response.setContent(entity.getContent());
         response.setCreatedAt(entity.getCreatedAt());    

--- a/backend/src/main/java/com/example/backend/notice/service/impl/NoticeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/notice/service/impl/NoticeServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.backend.notice.service.impl;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.backend.group.model.GroupEntity;
 import com.example.backend.group.repository.GroupMemberRepository;
 import com.example.backend.group.repository.GroupRepository;
+import com.example.backend.notice.dto.GetGroupIdAndGroupNameRecord;
 import com.example.backend.notice.dto.NoticeInsertRequest;
 import com.example.backend.notice.dto.NoticeListResponse;
 import com.example.backend.notice.dto.NoticeModifyRequest;
@@ -49,13 +52,17 @@ public class NoticeServiceImpl implements NoticeService {
             throw new IllegalArgumentException("そのユーザーは存在しません。");
         }
 
-        List<Integer> joinedGroupIds = groupMemberRepository.findJoinedGroupIdsByUserId(userId);
-        if (joinedGroupIds.isEmpty()) {
+        List<Integer> targetGroupIds = groupMemberRepository.findJoinedGroupIdsByUserId(userId);
+        if (targetGroupIds.isEmpty()) {
             return List.of();
         }
 
-        List<NoticeEntity> notices = noticeRepository.findAllByGroupIdIn(joinedGroupIds);
-        return notices.stream().map(noticeHelper::toNoticeListResponse).toList();
+        List<NoticeEntity> notices = noticeRepository.findAllByGroupIdIn(targetGroupIds);
+        List<GetGroupIdAndGroupNameRecord> records = groupRepository.findGroupNameByGroupIdIn(notices.stream().map(NoticeEntity::getGroupId).distinct().toList());
+        Map<Integer, String> groupIdToNameMap = records.stream()
+            .collect(Collectors.toMap(record -> record.groupId(), record -> record.groupName()));
+
+        return notices.stream().map(notice -> noticeHelper.toNoticeListResponse(notice, groupIdToNameMap)).toList();
     }
 
     @Override
@@ -67,12 +74,16 @@ public class NoticeServiceImpl implements NoticeService {
 
         List<GroupEntity> groups = groupRepository.findBySchool_SchoolId(schoolId);
         if (groups.isEmpty()) {
-            throw new IllegalArgumentException("その学校にはグループが存在しません。");
+            throw new IllegalArgumentException("その学校には指定されたグループが存在しません。");
         }
 
-        List<Integer> groupIds = groups.stream().map(GroupEntity::getGroupId).toList();
+        List<Integer> groupIds = groups.stream().map(GroupEntity::getGroupId).distinct().toList();
         List<NoticeEntity> notices = noticeRepository.findAllByGroupIdIn(groupIds);
-        return notices.stream().map(noticeHelper::toNoticeListResponse).toList();
+        List<GetGroupIdAndGroupNameRecord> records = groupRepository.findGroupNameByGroupIdIn(notices.stream().map(NoticeEntity::getGroupId).distinct().toList());
+        Map<Integer, String> groupIdToNameMap = records.stream()
+            .collect(Collectors.toMap(record -> record.groupId(), record -> record.groupName()));
+
+        return notices.stream().map(notice -> noticeHelper.toNoticeListResponse(notice, groupIdToNameMap)).toList();
     }
 
     @Override


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー
#206
<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
#206
### イシュー番号(自動クローズ用)

close #206

## やったこと
- お知らせ一覧のレスポンスをするJSONにグループ名を含む処理を追加
<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？

## やらないこと
- とくに無し
<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）
- そのお知らせがどこ向けのお知らせなのか把握することが出来る
- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）
- とくに無し
- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認
- Postmanで動作確認済み
- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？

## 影響範囲
- お知らせのフロント
<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」

## テスト
- とくに無し
<!-- テスト方法や結果 -->

- ない場合は「無し」

## 備考
- fileChengesのNoticeListResponse.javaを確認してレスポンスの型と名前が問題ないことを確認してください
- 出力の例はDiscordの#質問@飯塚に貼ってあります
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
