### PR TITLE
初回ログイン時のプロフィール作成で作成処理が走らない: frontend 

### DIFF
--- a/frontend/src/app/routes/auth/login.tsx
+++ b/frontend/src/app/routes/auth/login.tsx
@@ -2,13 +2,15 @@ import { useForm } from "react-hook-form";
 import { Header } from "@/components/ui/header/header.tsx";
 import { Button } from "@/components/ui/button/button.tsx";
 import { Input } from "@/components/ui/input/input.tsx";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import styles from "@/features/auth/styles/login.module.css";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { type LoginInfo } from "@/features/auth/types/auth";
 
 export const Login = () => {
   const { login, isLoggingIn } = useAuth();
+  const location = useLocation();
+  const errorMessage = location.state?.errorMessage;
 
   const { register, handleSubmit, formState } = useForm<LoginInfo>();
 
@@ -20,6 +22,9 @@ export const Login = () => {
     <>
       <Header />
       <form className={styles.loginContainer} onSubmit={handleSubmit(onSubmit)}>
+        {errorMessage && (
+          <div className={styles.errorMessage}>{errorMessage}</div>
+        )}
         <Input
           label="ユーザーID"
           type="text"

--- a/frontend/src/features/auth/components/protectedRoute.tsx
+++ b/frontend/src/features/auth/components/protectedRoute.tsx
@@ -10,20 +10,27 @@ import { Spinner } from "@/components/ui/spinner/spinner";
 const ProtectedRoute = () => {
   const { authToken } = useAuth();
 
-  const { data: user, error, isLoading: isUserLoading } = useUser(authToken);
+  const {
+    data: user,
+    error: getUserError,
+    isLoading: isUserLoading,
+  } = useUser(authToken);
 
-  const { mutate: createProfileMutate, isPending: isCreating } =
-    useCreateProfile(authToken);
+  const {
+    mutate: createProfileMutate,
+    isPending: isCreating,
+    error: createProfileError,
+  } = useCreateProfile(authToken);
 
   const hasShownError = useRef(false);
   const hasTriggeredCreation = useRef(false);
 
   useEffect(() => {
-    if (!error) return;
+    if (!getUserError) return;
 
     if (
-      error instanceof ApiRequestError &&
-      error.statusMessage === "NOT_FOUND"
+      getUserError instanceof ApiRequestError &&
+      getUserError.statusMessage === "NOT_FOUND"
     ) {
       if (!hasTriggeredCreation.current) {
         hasTriggeredCreation.current = true;
@@ -36,7 +43,7 @@ const ProtectedRoute = () => {
       alert("ユーザ情報の取得に失敗しました。");
       hasShownError.current = true;
     }
-  }, [error, createProfileMutate]);
+  }, [getUserError, createProfileMutate]);
 
   if (!authToken) {
     return <Navigate to={paths.auth.login.path} replace />;
@@ -50,15 +57,38 @@ const ProtectedRoute = () => {
     return <Outlet />;
   }
 
-  if (error) {
+  if (getUserError) {
     const isNotFound =
-      error instanceof ApiRequestError && error.statusMessage === "NOT_FOUND";
+      getUserError instanceof ApiRequestError &&
+      getUserError.statusMessage === "NOT_FOUND";
 
-    if (isNotFound) {
+    if (isNotFound && !createProfileError) {
       return <Spinner isDark={true} />;
     }
 
-    return <Navigate to={paths.auth.login.path} replace />;
+    if (createProfileError) {
+      return (
+        <Navigate
+          to={paths.auth.login.path}
+          replace
+          state={{
+            errorMessage:
+              "プロフィールの作成に失敗しました。再度ログインしてください。",
+          }}
+        />
+      );
+    }
+
+    return (
+      <Navigate
+        to={paths.auth.login.path}
+        replace
+        state={{
+          errorMessage:
+            "ユーザー情報の取得に失敗しました。再度ログインしてください。",
+        }}
+      />
+    );
   }
 
   return <Outlet />;

--- a/frontend/src/features/auth/components/protectedRoute.tsx
+++ b/frontend/src/features/auth/components/protectedRoute.tsx
@@ -51,7 +51,14 @@ const ProtectedRoute = () => {
   }
 
   if (error) {
-    return <Navigate to={paths.welcome.path} replace />;
+    const isNotFound =
+      error instanceof ApiRequestError && error.statusMessage === "NOT_FOUND";
+
+    if (isNotFound) {
+      return <Spinner isDark={true} />;
+    }
+
+    return <Navigate to={paths.auth.login.path} replace />;
   }
 
   return <Outlet />;

--- a/frontend/src/features/auth/hooks/useCreateProfile.ts
+++ b/frontend/src/features/auth/hooks/useCreateProfile.ts
@@ -24,5 +24,6 @@ export const useCreateProfile = (authToken: string) => {
       queryClient.invalidateQueries({ queryKey: ["user", jwtPayload?.sub] });
       alert("プロフィールが作成されていなかったため、作成しました");
     },
+    throwOnError: false,
   });
 };

--- a/frontend/src/features/auth/hooks/useUser.ts
+++ b/frontend/src/features/auth/hooks/useUser.ts
@@ -34,6 +34,7 @@ export const useUser = (authToken: string) => {
       };
     },
     staleTime: 1000 * 60 * 10,
+    throwOnError: false,
     retry: false,
   });
 };

--- a/frontend/src/features/auth/styles/login.module.css
+++ b/frontend/src/features/auth/styles/login.module.css
@@ -12,6 +12,17 @@
   box-sizing: border-box;
 }
 
+.errorMessage {
+  width: 100%;
+  padding: 12px 16px;
+  background-color: #fee;
+  color: #c33;
+  border: 1px solid #fcc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 .loginLinks {
   width: 100%;
   display: flex;


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク
https://github.com/CERS-Projects/Tuna/issues/214

### イシュー番号(自動クローズ用)

close #214

## やったこと

<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？
- 初回ログイン時の初期プロフィール作成処理がうまく機能しない問題を解決した

## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
- 無し

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
- ログインができるようになる

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
- 無し

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？
- プロフィールが作成されていないユーザでログインし、プロフィールが作成されログインできることを確認した。

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」
- なし

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」
- なし

## 備考

<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
