### PR TITLE
投稿機能の一部に確認処理を追加する: backend

### DIFF
--- a/backend/src/main/java/com/example/backend/posts/controller/PostController.java
+++ b/backend/src/main/java/com/example/backend/posts/controller/PostController.java
@@ -89,7 +89,7 @@ public class PostController {
             Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> userPosts;
 
-        userPosts = postService.getUserPosts(authentication,targetUserId, userInfo.getUserId(), userInfo.getSchoolId());
+        userPosts = postService.getUserPosts(authentication, targetUserId, userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok(userPosts);
     }
 
@@ -176,16 +176,16 @@ public class PostController {
     public ResponseEntity<List<PostDetailResponse>> getLikedPosts(Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> likedPosts;
 
-        likedPosts = likeService.getLikedPosts(authentication,userInfo.getUserId(), userInfo.getSchoolId());
+        likedPosts = likeService.getLikedPosts(authentication, userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok(likedPosts);
     }
-    
+
     //他ユーザのいいね取得
     @GetMapping("/likes/{targetUserId}")
     public ResponseEntity<List<PostDetailResponse>> getLikedPostsOfOtherUser(@PathVariable final Integer targetUserId,
             Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> likedPosts;
-        likedPosts = likeService.getLikedPosts(authentication,targetUserId, userInfo.getSchoolId());
+        likedPosts = likeService.getLikedPosts(authentication, targetUserId, userInfo.getSchoolId());
         return ResponseEntity.ok(likedPosts);
     }
 

--- a/backend/src/main/java/com/example/backend/posts/controller/PostController.java
+++ b/backend/src/main/java/com/example/backend/posts/controller/PostController.java
@@ -47,8 +47,9 @@ public class PostController {
 
     // 投稿を作成
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> insertPost(@Valid @ModelAttribute final PostInsertRequest postRequest,
-            @AuthenticationPrincipal final UserInfo userInfo) {
+    public ResponseEntity<Void> insertPost(@Valid
+        @ModelAttribute final PostInsertRequest postRequest,
+            Authentication authentication ,@AuthenticationPrincipal final UserInfo userInfo) {
         // JWTから取得したユーザーIDをセット
         log.info("投稿の作成を開始しました。 " + "userId: {}, content: {}, imageCount: {}",
                 userInfo.getUserId(),
@@ -57,7 +58,7 @@ public class PostController {
                 postRequest.getShareRange(),
                 postRequest.getImageFile() != null ? postRequest.getImageFile().size() : 0);
 
-        postService.insertPost(postRequest, userInfo.getUserId());
+        postService.insertPost(authentication, postRequest, userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok().build();
     }
 
@@ -85,10 +86,10 @@ public class PostController {
     // ユーザー投稿を取得
     @GetMapping("/profile")
     public ResponseEntity<List<PostDetailResponse>> getUserPosts(@RequestParam final Integer targetUserId,
-            @AuthenticationPrincipal final UserInfo userInfo) {
+            Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> userPosts;
 
-        userPosts = postService.getUserPosts(targetUserId, userInfo.getUserId());
+        userPosts = postService.getUserPosts(authentication,targetUserId, userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok(userPosts);
     }
 
@@ -143,9 +144,9 @@ public class PostController {
     // ブックマーク取得
     @GetMapping("/bookmarks")
     public ResponseEntity<List<PostDetailResponse>> getBookmarkedPosts(
-            @AuthenticationPrincipal final UserInfo userInfo) {
+            Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> bookmarkedPosts;
-        bookmarkedPosts = bookmarkService.getBookmarkedPosts(userInfo.getUserId());
+        bookmarkedPosts = bookmarkService.getBookmarkedPosts(authentication, userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok(bookmarkedPosts);
     }
 
@@ -172,10 +173,10 @@ public class PostController {
 
     // いいね取得
     @GetMapping("/likes")
-    public ResponseEntity<List<PostDetailResponse>> getLikedPosts(@AuthenticationPrincipal final UserInfo userInfo) {
+    public ResponseEntity<List<PostDetailResponse>> getLikedPosts(Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> likedPosts;
 
-        likedPosts = likeService.getLikedPosts(userInfo.getUserId());
+        likedPosts = likeService.getLikedPosts(authentication,userInfo.getUserId(), userInfo.getSchoolId());
         return ResponseEntity.ok(likedPosts);
     }
 

--- a/backend/src/main/java/com/example/backend/posts/controller/PostController.java
+++ b/backend/src/main/java/com/example/backend/posts/controller/PostController.java
@@ -171,12 +171,21 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
-    // いいね取得
+    // 自身のいいね取得
     @GetMapping("/likes")
     public ResponseEntity<List<PostDetailResponse>> getLikedPosts(Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> likedPosts;
 
         likedPosts = likeService.getLikedPosts(authentication,userInfo.getUserId(), userInfo.getSchoolId());
+        return ResponseEntity.ok(likedPosts);
+    }
+    
+    //他ユーザのいいね取得
+    @GetMapping("/likes/{targetUserId}")
+    public ResponseEntity<List<PostDetailResponse>> getLikedPostsOfOtherUser(@PathVariable final Integer targetUserId,
+            Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
+        List<PostDetailResponse> likedPosts;
+        likedPosts = likeService.getLikedPosts(authentication,targetUserId, userInfo.getSchoolId());
         return ResponseEntity.ok(likedPosts);
     }
 

--- a/backend/src/main/java/com/example/backend/posts/controller/PostController.java
+++ b/backend/src/main/java/com/example/backend/posts/controller/PostController.java
@@ -185,7 +185,7 @@ public class PostController {
     public ResponseEntity<List<PostDetailResponse>> getLikedPostsOfOtherUser(@PathVariable final Integer targetUserId,
             Authentication authentication, @AuthenticationPrincipal final UserInfo userInfo) {
         List<PostDetailResponse> likedPosts;
-        likedPosts = likeService.getLikedPosts(authentication, targetUserId, userInfo.getSchoolId());
+        likedPosts = likeService.getOtherUserLikedPosts(authentication, userInfo.getUserId(), userInfo.getSchoolId(), targetUserId);
         return ResponseEntity.ok(likedPosts);
     }
 

--- a/backend/src/main/java/com/example/backend/posts/helper/PostPermissionHelper.java
+++ b/backend/src/main/java/com/example/backend/posts/helper/PostPermissionHelper.java
@@ -22,4 +22,9 @@ public class PostPermissionHelper {
 
         return postShareRange.stream().anyMatch(userGroups::contains);
     }
+
+    // ユーザーの所属グループIDを取得
+    public List<Integer> getUserGroupIds(Integer userId) {
+        return groupJoinByUserId.getJoinedGroupIdsByUserId(userId);
+    }
 }

--- a/backend/src/main/java/com/example/backend/posts/helper/PostPermissionHelper.java
+++ b/backend/src/main/java/com/example/backend/posts/helper/PostPermissionHelper.java
@@ -1,0 +1,25 @@
+package com.example.backend.posts.helper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import com.example.backend.utils.accountConfirm.GroupJoinByUserId;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostPermissionHelper {
+
+    private final GroupJoinByUserId groupJoinByUserId;
+    
+    // 投稿閲覧権限確認
+    public boolean canViewPost(Integer userId, List<Integer> postShareRange) {
+        Set<Integer> userGroups = new HashSet<>(
+                groupJoinByUserId.getJoinedGroupIdsByUserId(userId));
+        userGroups.add(0);
+
+        return postShareRange.stream().anyMatch(userGroups::contains);
+    }
+}

--- a/backend/src/main/java/com/example/backend/posts/service/BookmarkService.java
+++ b/backend/src/main/java/com/example/backend/posts/service/BookmarkService.java
@@ -2,6 +2,7 @@ package com.example.backend.posts.service;
 
 
 import com.example.backend.posts.dto.PostDetailResponse;
+import org.springframework.security.core.Authentication;
 import java.util.List;
 import org.bson.types.ObjectId;
 
@@ -11,5 +12,5 @@ public interface BookmarkService {
     //ブックマーク削除
     void removeBookmark(ObjectId postId, Integer userId);
     //ユーザーのブックマーク取得
-    List<PostDetailResponse> getBookmarkedPosts(Integer userId);
+    List<PostDetailResponse> getBookmarkedPosts(Authentication authentication, Integer userId, Integer schoolId);
 }

--- a/backend/src/main/java/com/example/backend/posts/service/LikeService.java
+++ b/backend/src/main/java/com/example/backend/posts/service/LikeService.java
@@ -1,6 +1,7 @@
 package com.example.backend.posts.service;
 
 import com.example.backend.posts.dto.PostDetailResponse;
+import org.springframework.security.core.Authentication;
 import org.bson.types.ObjectId;
 import java.util.List;
 
@@ -10,7 +11,7 @@ public interface LikeService {
     //いいね削除
     void removeLikes(ObjectId postId, Integer userId);
     //いいね取得
-    List<PostDetailResponse> getLikedPosts(Integer userId);
+    List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId);
 
 
 }

--- a/backend/src/main/java/com/example/backend/posts/service/LikeService.java
+++ b/backend/src/main/java/com/example/backend/posts/service/LikeService.java
@@ -12,6 +12,8 @@ public interface LikeService {
     void removeLikes(ObjectId postId, Integer userId);
     //いいね取得
     List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId);
+    //他ユーザーいいね取得
+    List<PostDetailResponse> getOtherUserLikedPosts(Authentication authentication, Integer currentUserId, Integer schoolId, Integer targetUserId);
 
 
 }

--- a/backend/src/main/java/com/example/backend/posts/service/PostService.java
+++ b/backend/src/main/java/com/example/backend/posts/service/PostService.java
@@ -10,13 +10,13 @@ import com.example.backend.posts.dto.PostInsertRequest;
 
 public interface PostService {
 
-    void insertPost(PostInsertRequest post, Integer userId);
+    void insertPost(Authentication authentication, PostInsertRequest post, Integer userId, Integer schoolId);
 
     PostDetailResponse getPostById(Authentication authentication, String postId, UserInfo userInfo);
 
     List<PostDetailResponse> getTimelinePosts(Integer shareRange, Authentication authentication, UserInfo userInfo);
 
-    List<PostDetailResponse> getUserPosts(Integer targetUserId, Integer currentUserId);
+    List<PostDetailResponse> getUserPosts(Authentication authentication, Integer targetUserId, Integer currentUserId, Integer schoolId);
 
     List<PostDetailResponse> getReplyPosts(String replypostId, Integer currentUserId);
 

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -5,14 +5,19 @@ import com.example.backend.posts.service.BookmarkService;
 import com.example.backend.posts.repository.BookmarkRepository;
 import com.example.backend.utils.fileUtil.helper.FileControlHelper;
 import com.example.backend.posts.repository.PostRepository;
-
+import com.example.backend.posts.helper.PostPermissionHelper;
+import org.springframework.security.core.Authentication;
 import com.example.backend.posts.model.BookmarkEntity;
+import com.example.backend.utils.accountConfirm.AccountConfirm;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import org.bson.types.ObjectId;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Iterator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +34,10 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final FileControlHelper fileControlHelper;
 
     private final PostRepository postRepository;
+
+    private final PostPermissionHelper postPermissionHelper;
+
+    private final AccountConfirm accountConfirm;
 
     //投稿の存在確認
     private boolean existsPost(ObjectId postId) {
@@ -66,6 +75,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         }
     }
 
+    //ブックマークの削除
     @Override
     public void removeBookmark(ObjectId postId, Integer userId) {
 
@@ -81,15 +91,35 @@ public class BookmarkServiceImpl implements BookmarkService {
             throw new RuntimeException("ブックマークの削除に失敗しました");
         }
     }
+
+    //ブックマーク投稿の取得
     @Override
-    public List<PostDetailResponse> getBookmarkedPosts(Integer userId) {
+    public List<PostDetailResponse> getBookmarkedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = null;
+        Set<Integer> getShaRengeList = new HashSet<>();
+        boolean isAdminorTeacher = authentication.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         try{
             postDetails = bookmarkRepository.findByBookmarked(userId);
 
-            for (PostDetailResponse postDetail : postDetails) {
+            Iterator<PostDetailResponse> iterator = postDetails.iterator();
+            while (iterator.hasNext()) {
+                PostDetailResponse postDetail = iterator.next();
+                if(!isAdminorTeacher){
+                    if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
+                        iterator.remove();
+                        continue;
+                    }
+                }
+                getShaRengeList.addAll(postDetail.getShareRange());
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            }
+            if(isAdminorTeacher){
+                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRengeList.toArray(new Integer[0]))){
+                    log.error("取得したブックマークに学校に所属していないグループが含まれています userId: {} and schoolId: {} groups: {}", userId, schoolId,getShaRengeList);
+                    throw new RuntimeException("取得したブックマークに学校に所属していないグループが含まれています");
+                }
             }
 
         } catch(Exception e) {

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.backend.utils.accountConfirm.AccountConfirm;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.ArrayList;
 import java.util.List;
 import org.bson.types.ObjectId;
 import java.util.Set;
@@ -96,45 +97,56 @@ public class BookmarkServiceImpl implements BookmarkService {
     @Override
     public List<PostDetailResponse> getBookmarkedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = List.of();
-        Set<Integer> getShaRangeList = new HashSet<>();
-        boolean isAdminorTeacher = authentication.getAuthorities().stream()
+        HashSet<Integer> shareRangeList = new HashSet<>();
+        boolean isAdminOrTeacher = authentication.getAuthorities().stream()
                 .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
-            try{
-                postDetails = bookmarkRepository.findByBookmarked(userId);
-            } catch(Exception e){
-                log.error("ブックマーク投稿の取得に失敗しました userId: {} エラー: {}" , userId, e);
-                throw new RuntimeException("ブックマーク投稿の取得に失敗しました");
-            }
-            Iterator<PostDetailResponse> iterator = postDetails.iterator();
+        try{
+            postDetails = bookmarkRepository.findByBookmarked(userId);
+        } catch(Exception e){
+            log.error("ブックマーク投稿の取得に失敗しました userId: {} エラー: {}" , userId, e);
+            throw new RuntimeException("ブックマーク投稿の取得に失敗しました");
+        }
 
-            try{
-                while (iterator.hasNext()) {
-                    PostDetailResponse postDetail = iterator.next();
-                    if(!isAdminorTeacher){
-                        if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
-                            iterator.remove();
-                            continue;
-                        }
+        Set<Integer> userGroups = null;
+        if (!isAdminOrTeacher) {
+            userGroups = new HashSet<>(postPermissionHelper.getUserGroupIds(userId));
+            userGroups.add(0);
+        }
+
+        Iterator<PostDetailResponse> iterator = postDetails.iterator();
+        try{
+            while (iterator.hasNext()) {
+                PostDetailResponse postDetail = iterator.next();
+
+                // 一般ユーザー: 閲覧権限チェック
+                if (!isAdminOrTeacher && userGroups != null) {
+                    if (postDetail.getShareRange().stream().noneMatch(userGroups::contains)) {
+                        iterator.remove();
+                        continue;
                     }
-                    if(!postDetail.getShareRange().contains(0)){
-                        getShaRangeList.addAll(postDetail.getShareRange());
-                    }
-                    postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
-                    postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
-                    
                 }
-            } catch(Exception e){
-                log.error("ブックマーク投稿の処理中にエラーが発生しました userId: {} エラー: {}" , userId, e);
-                throw new RuntimeException("ブックマーク投稿の処理中にエラーが発生しました");
+                // 管理者/教師: 学校の場合 shareRangeを集約
+                if (isAdminOrTeacher && postDetail.getShareRange().contains(0)) {
+                    shareRangeList.addAll(postDetail.getShareRange());
                 }
-            
-            
-            if(isAdminorTeacher){
-                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
-                    log.error("取得したブックマークに学校に所属していないグループが含まれています userId: {} and schoolId: {} groups: {}", userId, schoolId,getShaRangeList);
-                    throw new RuntimeException("取得したブックマークに学校に所属していないグループが含まれています");
+
+
+                postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
+                postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            }
+
+            // 管理者/教師: 学校に所属しない投稿があった場合はエラー
+            if (isAdminOrTeacher && shareRangeList != null) {
+                if(!accountConfirm.isAllGroupsBelongToSchool(schoolId, new ArrayList<>(shareRangeList))) {
+                    throw new RuntimeException("学校に所属しないグループの投稿が含まれています、他校向けの投稿は表示できません");
                 }
             }
+        } catch(Exception e){
+            log.error("ブックマーク投稿の処理中にエラーが発生しました userId: {} エラー: {}" , userId, e);
+            throw new RuntimeException("ブックマーク投稿の処理中にエラーが発生しました");
+        }
+
+        log.info("ブックマーク投稿の取得に成功しました userId: {}", userId);
         return postDetails;
     }
 }

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -126,7 +126,7 @@ public class BookmarkServiceImpl implements BookmarkService {
                     }
                 }
                 // 管理者/教師: 学校の場合 shareRangeを集約
-                if (isAdminOrTeacher && postDetail.getShareRange().contains(0)) {
+                if (isAdminOrTeacher && !postDetail.getShareRange().contains(0)) {
                     shareRangeList.addAll(postDetail.getShareRange());
                 }
 

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -95,37 +95,46 @@ public class BookmarkServiceImpl implements BookmarkService {
     //ブックマーク投稿の取得
     @Override
     public List<PostDetailResponse> getBookmarkedPosts(Authentication authentication, Integer userId, Integer schoolId) {
-        List<PostDetailResponse> postDetails = null;
+        List<PostDetailResponse> postDetails = List.of();
         Set<Integer> getShaRangeList = new HashSet<>();
         boolean isAdminorTeacher = authentication.getAuthorities().stream()
                 .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
-        try{
-            postDetails = bookmarkRepository.findByBookmarked(userId);
-
-            Iterator<PostDetailResponse> iterator = postDetails.iterator();
-            while (iterator.hasNext()) {
-                PostDetailResponse postDetail = iterator.next();
-                if(!isAdminorTeacher){
-                    if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
-                        iterator.remove();
-                        continue;
-                    }
-                }
-                getShaRangeList.addAll(postDetail.getShareRange());
-                postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
-                postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            try{
+                postDetails = bookmarkRepository.findByBookmarked(userId);
+            } catch(Exception e){
+                log.error("ブックマーク投稿の取得に失敗しました userId: {} エラー: {}" , userId, e);
+                throw new RuntimeException("ブックマーク投稿の取得に失敗しました");
             }
+            Iterator<PostDetailResponse> iterator = postDetails.iterator();
+
+            try{
+                while (iterator.hasNext()) {
+                    PostDetailResponse postDetail = iterator.next();
+                    if(!isAdminorTeacher){
+                        if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
+                            iterator.remove();
+                            continue;
+                        }
+                    }
+                    if(!postDetail.getShareRange().contains(0)){
+                        getShaRangeList.addAll(postDetail.getShareRange());
+                    }
+                    postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
+                    postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+                    
+                }
+            } catch(Exception e){
+                log.error("ブックマーク投稿の処理中にエラーが発生しました userId: {} エラー: {}" , userId, e);
+                throw new RuntimeException("ブックマーク投稿の処理中にエラーが発生しました");
+                }
+            
+            
             if(isAdminorTeacher){
                 if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
                     log.error("取得したブックマークに学校に所属していないグループが含まれています userId: {} and schoolId: {} groups: {}", userId, schoolId,getShaRangeList);
                     throw new RuntimeException("取得したブックマークに学校に所属していないグループが含まれています");
                 }
             }
-
-        } catch(Exception e) {
-            log.error("ブックマーク投稿の取得に失敗しました userId: {} エラー: {}", userId, e);
-            throw new RuntimeException("ブックマーク投稿の取得に失敗しました");
-        }
         return postDetails;
     }
 }

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -99,7 +99,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         List<PostDetailResponse> postDetails = List.of();
         HashSet<Integer> shareRangeList = new HashSet<>();
         boolean isAdminOrTeacher = authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         try{
             postDetails = bookmarkRepository.findByBookmarked(userId);
         } catch(Exception e){

--- a/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/BookmarkServiceImpl.java
@@ -96,9 +96,9 @@ public class BookmarkServiceImpl implements BookmarkService {
     @Override
     public List<PostDetailResponse> getBookmarkedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = null;
-        Set<Integer> getShaRengeList = new HashSet<>();
+        Set<Integer> getShaRangeList = new HashSet<>();
         boolean isAdminorTeacher = authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         try{
             postDetails = bookmarkRepository.findByBookmarked(userId);
 
@@ -111,13 +111,13 @@ public class BookmarkServiceImpl implements BookmarkService {
                         continue;
                     }
                 }
-                getShaRengeList.addAll(postDetail.getShareRange());
+                getShaRangeList.addAll(postDetail.getShareRange());
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
             }
             if(isAdminorTeacher){
-                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRengeList.toArray(new Integer[0]))){
-                    log.error("取得したブックマークに学校に所属していないグループが含まれています userId: {} and schoolId: {} groups: {}", userId, schoolId,getShaRengeList);
+                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
+                    log.error("取得したブックマークに学校に所属していないグループが含まれています userId: {} and schoolId: {} groups: {}", userId, schoolId,getShaRangeList);
                     throw new RuntimeException("取得したブックマークに学校に所属していないグループが含まれています");
                 }
             }

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -165,6 +165,7 @@ public class LikeServiceImpl implements LikeService {
     @Override
     public List<PostDetailResponse> getOtherUserLikedPosts(Authentication authentication, Integer currentUserId, Integer schoolId, Integer targetUserId) {
         List<PostDetailResponse> postDetails = List.of();
+        HashSet<Integer> shareRangeList = new HashSet<>();
         boolean isAdminOrTeacher = authentication.getAuthorities().stream()
                 .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         
@@ -195,19 +196,18 @@ public class LikeServiceImpl implements LikeService {
                 }
 
                 // 管理者/教師: 学校に所属しないグループの投稿を除外
-                if (isAdminOrTeacher) {
-                    List<Integer> nonGlobalIds = postDetail.getShareRange().stream()
-                            .filter(id -> id != 0)
-                            .toList();
-                    if (!nonGlobalIds.isEmpty() && !accountConfirm.isAllGroupsBelongToSchool(schoolId, new ArrayList<>(nonGlobalIds))) {
-                        log.warn("学校に所属していないグループを含む投稿を除外しました userId: {} postId: {} groups: {}", currentUserId, postDetail.getPostId(), postDetail.getShareRange());
-                        iterator.remove();
-                        continue;
-                    }
+                if (isAdminOrTeacher && postDetail.getShareRange().contains(0)) {
+                    shareRangeList.addAll(postDetail.getShareRange());
                 }
 
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            }
+            // 管理者/教師: 学校に所属しない投稿があった場合はエラー
+            if (isAdminOrTeacher && shareRangeList != null) {
+                if(!accountConfirm.isAllGroupsBelongToSchool(schoolId, new ArrayList<>(shareRangeList))) {
+                    throw new RuntimeException("学校に所属しないグループの投稿が含まれています、他校向けの投稿は表示できません");
+                }
             }
         } catch(Exception e){
             log.error("いいねした投稿の処理中にエラーが発生しました userId: {} エラー: {}", currentUserId, e);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.backend.utils.accountConfirm.AccountConfirm;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Set;
 import java.util.Iterator;
@@ -106,8 +107,7 @@ public class LikeServiceImpl implements LikeService {
     @Override
     public List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = List.of();
-        Set<Integer> getShaRangeList = new HashSet<>();
-        boolean isAdminorTeacher = authentication.getAuthorities().stream()
+        boolean isAdminOrTeacher = authentication.getAuthorities().stream()
                 .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         
         try{
@@ -116,39 +116,106 @@ public class LikeServiceImpl implements LikeService {
             log.error("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, e);
             throw new RuntimeException("いいねした投稿の取得に失敗しました");
         }
+
+        Set<Integer> userGroups = null;
+        if (!isAdminOrTeacher) {
+            userGroups = new HashSet<>(postPermissionHelper.getUserGroupIds(userId));
+            userGroups.add(0);
+        }
         
         Iterator<PostDetailResponse> iterator = postDetails.iterator();
         try{
             while (iterator.hasNext()) {
                 PostDetailResponse postDetail = iterator.next();
-                if(!isAdminorTeacher){
-                    if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
+
+                // 一般ユーザー: 閲覧権限チェック
+                if (!isAdminOrTeacher) {
+                    if (postDetail.getShareRange().stream().noneMatch(userGroups::contains)) {
                         iterator.remove();
                         continue;
                     }
                 }
 
-                if(!postDetail.getShareRange().contains(0)){
-                    getShaRangeList.addAll(postDetail.getShareRange());
+                // 管理者/教師: 学校に所属しないグループの投稿を除外
+                if (isAdminOrTeacher) {
+                    List<Integer> nonGlobalIds = postDetail.getShareRange().stream()
+                            .filter(id -> id != 0)
+                            .toList();
+                    if (!nonGlobalIds.isEmpty() && !accountConfirm.isAllGroupsBelongToSchool(schoolId, new ArrayList<>(nonGlobalIds))) {
+                        log.warn("学校に所属していないグループを含む投稿を除外しました userId: {} postId: {} groups: {}", userId, postDetail.getPostId(), postDetail.getShareRange());
+                        iterator.remove();
+                        continue;
+                    }
                 }
 
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
-                }
+            }
         } catch(Exception e){
             log.error("いいねした投稿の処理中にエラーが発生しました userId: {} エラー: {}", userId, e);
             throw new RuntimeException("いいねした投稿の処理中にエラーが発生しました");
-            }
+        }
 
-            if(isAdminorTeacher){
-                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
-                    log.info("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, "権限のないグループが含まれています");
-                    throw new RuntimeException("いいねした投稿の取得に失敗しました");
+        log.info("いいねした投稿の取得に成功しました userId: {}", userId);
+        return postDetails;
+        
+    }
+
+    //他ユーザーいいね取得
+    @Override
+    public List<PostDetailResponse> getOtherUserLikedPosts(Authentication authentication, Integer currentUserId, Integer schoolId, Integer targetUserId) {
+        List<PostDetailResponse> postDetails = List.of();
+        boolean isAdminOrTeacher = authentication.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+        
+        try{
+            postDetails = likeRepository.findByLiked(targetUserId);
+        } catch(Exception e){
+            log.error("いいねした投稿の取得に失敗しました userId: {} エラー: {}", targetUserId, e);
+            throw new RuntimeException("いいねした投稿の取得に失敗しました");
+        }
+
+        Set<Integer> userGroups = null;
+        if (!isAdminOrTeacher) {
+            userGroups = new HashSet<>(postPermissionHelper.getUserGroupIds(currentUserId));
+            userGroups.add(0);
+        }
+        
+        Iterator<PostDetailResponse> iterator = postDetails.iterator();
+        try{
+            while (iterator.hasNext()) {
+                PostDetailResponse postDetail = iterator.next();
+
+                // 一般ユーザー: 閲覧権限チェック
+                if (!isAdminOrTeacher && userGroups != null) {
+                    if (postDetail.getShareRange().stream().noneMatch(userGroups::contains)) {
+                        iterator.remove();
+                        continue;
+                    }
                 }
-            }
 
-            log.info("いいねした投稿の取得に成功しました userId: {}", userId);
-            return postDetails;
+                // 管理者/教師: 学校に所属しないグループの投稿を除外
+                if (isAdminOrTeacher) {
+                    List<Integer> nonGlobalIds = postDetail.getShareRange().stream()
+                            .filter(id -> id != 0)
+                            .toList();
+                    if (!nonGlobalIds.isEmpty() && !accountConfirm.isAllGroupsBelongToSchool(schoolId, new ArrayList<>(nonGlobalIds))) {
+                        log.warn("学校に所属していないグループを含む投稿を除外しました userId: {} postId: {} groups: {}", currentUserId, postDetail.getPostId(), postDetail.getShareRange());
+                        iterator.remove();
+                        continue;
+                    }
+                }
+
+                postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
+                postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            }
+        } catch(Exception e){
+            log.error("いいねした投稿の処理中にエラーが発生しました userId: {} エラー: {}", currentUserId, e);
+            throw new RuntimeException("いいねした投稿の処理中にエラーが発生しました");
+        }
+
+        log.info("いいねした投稿の取得に成功しました userId: {}", currentUserId);
+        return postDetails;
         
     }
 }

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -108,7 +108,7 @@ public class LikeServiceImpl implements LikeService {
     public List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = List.of();
         boolean isAdminOrTeacher = authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         
         try{
             postDetails = likeRepository.findByLiked(userId);
@@ -167,7 +167,7 @@ public class LikeServiceImpl implements LikeService {
         List<PostDetailResponse> postDetails = List.of();
         HashSet<Integer> shareRangeList = new HashSet<>();
         boolean isAdminOrTeacher = authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         
         try{
             postDetails = likeRepository.findByLiked(targetUserId);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -7,10 +7,16 @@ import com.example.backend.posts.repository.LikeRepository;
 import com.example.backend.utils.fileUtil.helper.FileControlHelper;
 import com.example.backend.posts.repository.PostCounterRepository;
 import com.example.backend.posts.repository.PostRepository;
+import com.example.backend.posts.helper.PostPermissionHelper;
+import org.springframework.security.core.Authentication;
+import com.example.backend.utils.accountConfirm.AccountConfirm;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Set;
+import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import com.example.backend.posts.dto.PostDetailResponse;
 import com.example.backend.posts.model.LikeEntity;
@@ -33,6 +39,10 @@ public class LikeServiceImpl implements LikeService {
     private final PostCounterRepository postCounterRepository;
 
     private final PostRepository postRepository;
+
+    private final PostPermissionHelper postPermissionHelper;
+
+    private final AccountConfirm accountConfirm;
 
 
     //投稿の存在確認
@@ -94,15 +104,31 @@ public class LikeServiceImpl implements LikeService {
     
     //いいね取得
     @Override
-    public List<PostDetailResponse> getLikedPosts(Integer userId) {
+    public List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = List.of();
-
+        Set<Integer> getShaRengeList = new HashSet<>();
+        boolean isAdminorTeacher = authentication.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+        
         try{
             postDetails = likeRepository.findByLiked(userId);
 
-            for (PostDetailResponse postDetail : postDetails) {
+            //閲覧権限確認(なかったら除外)とURL設定
+            Iterator<PostDetailResponse> iterator = postDetails.iterator();
+            while (iterator.hasNext()) {
+                PostDetailResponse postDetail = iterator.next();
+                if(!isAdminorTeacher){
+                    if (!postPermissionHelper.canViewPost(userId, postDetail.getShareRange())) {
+                        iterator.remove();
+                        continue;
+                    }
+                }
+                getShaRengeList.addAll(postDetail.getShareRange());
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+            }
+            if(isAdminorTeacher){
+                accountConfirm.isExistsAllGroups(schoolId, getShaRengeList.toArray(new Integer[0]));
             }
 
             log.info("いいねした投稿の取得に成功しました userId: {}", userId);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -112,9 +112,13 @@ public class LikeServiceImpl implements LikeService {
         
         try{
             postDetails = likeRepository.findByLiked(userId);
-
-            //閲覧権限確認(なかったら除外)とURL設定
-            Iterator<PostDetailResponse> iterator = postDetails.iterator();
+        } catch(Exception e){
+            log.error("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, e);
+            throw new RuntimeException("いいねした投稿の取得に失敗しました");
+        }
+        
+        Iterator<PostDetailResponse> iterator = postDetails.iterator();
+        try{
             while (iterator.hasNext()) {
                 PostDetailResponse postDetail = iterator.next();
                 if(!isAdminorTeacher){
@@ -123,10 +127,19 @@ public class LikeServiceImpl implements LikeService {
                         continue;
                     }
                 }
-                getShaRangeList.addAll(postDetail.getShareRange());
+
+                if(!postDetail.getShareRange().contains(0)){
+                    getShaRangeList.addAll(postDetail.getShareRange());
+                }
+
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
+                }
+        } catch(Exception e){
+            log.error("いいねした投稿の処理中にエラーが発生しました userId: {} エラー: {}", userId, e);
+            throw new RuntimeException("いいねした投稿の処理中にエラーが発生しました");
             }
+
             if(isAdminorTeacher){
                 if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
                     log.info("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, "権限のないグループが含まれています");
@@ -136,10 +149,7 @@ public class LikeServiceImpl implements LikeService {
 
             log.info("いいねした投稿の取得に成功しました userId: {}", userId);
             return postDetails;
-        } catch(Exception e){
-            log.error("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, e);
-            throw new RuntimeException("いいねした投稿の取得に失敗しました");
-        }
+        
     }
 }
 

--- a/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/LikeServiceImpl.java
@@ -106,9 +106,9 @@ public class LikeServiceImpl implements LikeService {
     @Override
     public List<PostDetailResponse> getLikedPosts(Authentication authentication, Integer userId, Integer schoolId) {
         List<PostDetailResponse> postDetails = List.of();
-        Set<Integer> getShaRengeList = new HashSet<>();
+        Set<Integer> getShaRangeList = new HashSet<>();
         boolean isAdminorTeacher = authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ADMIN_SCHOOL") || grantedAuthority.getAuthority().equals("ROLE_TEACHER"));
         
         try{
             postDetails = likeRepository.findByLiked(userId);
@@ -123,12 +123,15 @@ public class LikeServiceImpl implements LikeService {
                         continue;
                     }
                 }
-                getShaRengeList.addAll(postDetail.getShareRange());
+                getShaRangeList.addAll(postDetail.getShareRange());
                 postDetail.setImageUrl(fileControlHelper.getMultiFileUrl(postDetail.getImageUrl()));
                 postDetail.setIcon(fileControlHelper.getFileUrl(postDetail.getIcon()));
             }
             if(isAdminorTeacher){
-                accountConfirm.isExistsAllGroups(schoolId, getShaRengeList.toArray(new Integer[0]));
+                if(!accountConfirm.isExistsAllGroups(schoolId, getShaRangeList.toArray(new Integer[0]))){
+                    log.info("いいねした投稿の取得に失敗しました userId: {} エラー: {}", userId, "権限のないグループが含まれています");
+                    throw new RuntimeException("いいねした投稿の取得に失敗しました");
+                }
             }
 
             log.info("いいねした投稿の取得に成功しました userId: {}", userId);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
@@ -68,7 +68,7 @@ public class PostServiceImpl implements PostService {
         // 除外したリストをもとに権限確認（userGroupIdsが空でない場合のみ)
         if(!userGroupIds.isEmpty()) {
             boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                    .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
 
             if (!isTeacherOrAdmin) {
                 if (!accountConfirm.isExistsAllGroups(userId, userGroupIds.toArray(new Integer[0]))) {
@@ -138,7 +138,7 @@ public class PostServiceImpl implements PostService {
         List<Integer> shareRangeList = new java.util.ArrayList<>(List.of(shareRange));
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
 
         if (!isTeacherOrAdmin && !(shareRangeList.size() == 1 && shareRangeList.get(0) == 0)) {
 
@@ -187,7 +187,7 @@ public class PostServiceImpl implements PostService {
         List<Integer> userGroupIds = groupJoinByUserId.getJoinedGroupIdsByUserId(currentUserId);
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
         if (!isTeacherOrAdmin) {
             if (!accountConfirm.isExistsAllGroups(currentUserId, userGroupIds.toArray(new Integer[0]))) {
                 throw new IllegalArgumentException("指定されたグループに所属していません。");
@@ -245,7 +245,7 @@ public class PostServiceImpl implements PostService {
         Integer currentUserId = userInfo.getUserId();
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
 
         // publicの0を除外
         List<Integer> nonPublicGroupIds = shareRange.stream()
@@ -350,7 +350,7 @@ public class PostServiceImpl implements PostService {
         Integer currentUserId = userInfo.getUserId();
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
 
         try {
             log.info("投稿単体取得を開始しました 投稿ID: " + postId + " 取得 currentUserId: " + currentUserId);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
@@ -68,7 +68,7 @@ public class PostServiceImpl implements PostService {
         // 除外したリストをもとに権限確認（userGroupIdsが空でない場合のみ)
         if(!userGroupIds.isEmpty()) {
             boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                    .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
 
             if (!isTeacherOrAdmin) {
                 if (!accountConfirm.isExistsAllGroups(userId, userGroupIds.toArray(new Integer[0]))) {
@@ -138,7 +138,7 @@ public class PostServiceImpl implements PostService {
         List<Integer> shareRangeList = new java.util.ArrayList<>(List.of(shareRange));
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
 
         if (!isTeacherOrAdmin && !(shareRangeList.size() == 1 && shareRangeList.get(0) == 0)) {
 
@@ -187,7 +187,7 @@ public class PostServiceImpl implements PostService {
         List<Integer> userGroupIds = groupJoinByUserId.getJoinedGroupIdsByUserId(currentUserId);
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
         if (!isTeacherOrAdmin) {
             if (!accountConfirm.isExistsAllGroups(currentUserId, userGroupIds.toArray(new Integer[0]))) {
                 throw new IllegalArgumentException("指定されたグループに所属していません。");
@@ -245,7 +245,7 @@ public class PostServiceImpl implements PostService {
         Integer currentUserId = userInfo.getUserId();
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
 
         // publicの0を除外
         List<Integer> nonPublicGroupIds = shareRange.stream()
@@ -350,7 +350,7 @@ public class PostServiceImpl implements PostService {
         Integer currentUserId = userInfo.getUserId();
 
         boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ADMIN_SCHOOL"));
 
         try {
             log.info("投稿単体取得を開始しました 投稿ID: " + postId + " 取得 currentUserId: " + currentUserId);

--- a/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/posts/service/impl/PostServiceImpl.java
@@ -16,6 +16,7 @@ import com.example.backend.utils.accountConfirm.GroupJoinByUserId;
 import com.example.backend.posts.service.PostService;
 import com.example.backend.profile.repository.ProfileRepository;
 import com.example.backend.utils.fileUtil.helper.FileControlHelper;
+import com.example.backend.posts.helper.PostPermissionHelper;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -24,9 +25,7 @@ import lombok.RequiredArgsConstructor;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,11 +49,13 @@ public class PostServiceImpl implements PostService {
 
     private final GroupJoinByUserId groupJoinByUserId;
 
+    private final PostPermissionHelper postPermissionHelper;
+
     private final ProfileRepository profileRepository;
 
     // 投稿作成
     @Override
-    public void insertPost(PostInsertRequest post, Integer userId) {
+    public void insertPost(Authentication authentication, PostInsertRequest post, Integer userId, Integer schoolId) {
         PostEntity postEntity = new PostEntity();
         List<String> fileObjectKeys = null;
         List<MultipartFile> imageFiles = post.getImageFile();
@@ -64,10 +65,22 @@ public class PostServiceImpl implements PostService {
         List<Integer> userGroupIds = post.getShareRange().stream()
                 .filter(i -> i != 0)
                 .toList();
-        // 除外したリストをもとに権限確認（userGroupIdsが空でない場合のみ）
-        if (userGroupIds.size() != 0) {
-            if (!accountConfirm.isExistsAllGroups(userId, userGroupIds.toArray(new Integer[0]))) {
-                throw new IllegalArgumentException("指定されたグループに所属していません。");
+        // 除外したリストをもとに権限確認（userGroupIdsが空でない場合のみ)
+        if(!userGroupIds.isEmpty()) {
+            boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+
+            if (!isTeacherOrAdmin) {
+                if (!accountConfirm.isExistsAllGroups(userId, userGroupIds.toArray(new Integer[0]))) {
+                    throw new IllegalArgumentException("指定されたグループに所属していません。");
+                }
+            }
+
+            // 教師/管理者でも指定グループが自校のものか検証
+            if (isTeacherOrAdmin) {
+                if (!accountConfirm.isAllGroupsBelongToSchool(schoolId, userGroupIds)) {
+                    throw new IllegalArgumentException("指定されたグループは自校に属していません。");
+                }
             }
         }
 
@@ -169,12 +182,20 @@ public class PostServiceImpl implements PostService {
 
     // ユーザー投稿取得
     @Override
-    public List<PostDetailResponse> getUserPosts(Integer targetUserId, Integer currentUserId) {
+    public List<PostDetailResponse> getUserPosts(Authentication authentication, Integer targetUserId, Integer currentUserId, Integer schoolId) {
         List<PostDetailResponse> postDetails;
         List<Integer> userGroupIds = groupJoinByUserId.getJoinedGroupIdsByUserId(currentUserId);
 
-        if (!accountConfirm.isExistsAllGroups(currentUserId, userGroupIds.toArray(new Integer[0]))) {
-            throw new IllegalArgumentException("指定されたグループに所属していません。");
+        boolean isTeacherOrAdmin = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_TEACHER") || a.getAuthority().equals("ROLE_ADMIN_SCHOOL"));
+        if (!isTeacherOrAdmin) {
+            if (!accountConfirm.isExistsAllGroups(currentUserId, userGroupIds.toArray(new Integer[0]))) {
+                throw new IllegalArgumentException("指定されたグループに所属していません。");
+            }
+        }else {
+            if (!accountConfirm.isAllGroupsBelongToSchool(schoolId, userGroupIds)) {
+                throw new IllegalArgumentException("指定されたグループは自校に属していません。");
+            }
         }
         userGroupIds.add(0); // public権限を追加
 
@@ -349,7 +370,7 @@ public class PostServiceImpl implements PostService {
                     log.error("投稿の閲覧権限がありません（他校の投稿）。 投稿ID: " + postId);
                     throw new IllegalArgumentException("投稿の閲覧権限がありません。");
                 }
-            } else if (!canViewPost(currentUserId, postDetail.getShareRange())) {
+            } else if (!postPermissionHelper.canViewPost(currentUserId, postDetail.getShareRange())) {
                 log.error("投稿の閲覧権限がありません。 投稿ID: " + postId);
                 throw new IllegalArgumentException("投稿の閲覧権限がありません。");
             }
@@ -379,14 +400,5 @@ public class PostServiceImpl implements PostService {
         log.info("取得したミュートワードリスト: " + muteWordList);
 
         return muteWordList;
-    }
-
-    // 投稿閲覧権限確認
-    private boolean canViewPost(Integer userId, List<Integer> postShareRange) {
-        Set<Integer> userGroups = new HashSet<>(
-                groupJoinByUserId.getJoinedGroupIdsByUserId(userId));
-        userGroups.add(0);
-
-        return postShareRange.stream().anyMatch(userGroups::contains);
     }
 }

--- a/backend/src/main/java/com/example/backend/profile/controller/ProfileController.java
+++ b/backend/src/main/java/com/example/backend/profile/controller/ProfileController.java
@@ -125,9 +125,10 @@ public class ProfileController {
 
     // 他ユーザーのフォロー一覧取得
     @GetMapping("/following")
-    public ResponseEntity<List<FollowingProfileResponse>> getUserFollowing(@RequestParam Integer targetUserId) {
+    public ResponseEntity<List<FollowingProfileResponse>> getUserFollowing(@RequestParam Integer targetUserId,
+            @AuthenticationPrincipal UserInfo userInfo) {
         
-        List<FollowingProfileResponse> following = followQueryService.getFollowingAccounts(targetUserId);
+        List<FollowingProfileResponse> following = followQueryService.getOtherUserFollowingAccounts(targetUserId, userInfo.getUserId());
         return ResponseEntity.ok(following);
     }
 
@@ -141,9 +142,10 @@ public class ProfileController {
 
     // 他ユーザーのフォロワー一覧取得
     @GetMapping("/followers")
-    public ResponseEntity<List<FollowingProfileResponse>> getUserFollowers(@RequestParam Integer targetUserId) {
+    public ResponseEntity<List<FollowingProfileResponse>> getUserFollowers(@RequestParam Integer targetUserId,
+            @AuthenticationPrincipal UserInfo userInfo) {
         
-        List<FollowingProfileResponse> followers = followQueryService.getFollowerAccounts(targetUserId);
+        List<FollowingProfileResponse> followers = followQueryService.getOtherUserFollowerAccounts(targetUserId, userInfo.getUserId());
         return ResponseEntity.ok(followers);
     }
 

--- a/backend/src/main/java/com/example/backend/profile/service/FollowQueryService.java
+++ b/backend/src/main/java/com/example/backend/profile/service/FollowQueryService.java
@@ -9,6 +9,10 @@ public interface FollowQueryService {
     
     List<FollowingProfileResponse> getFollowerAccounts(Integer userId);
 
+    List<FollowingProfileResponse> getOtherUserFollowingAccounts(Integer targetUserId, Integer currentUserId);
+
+    List<FollowingProfileResponse> getOtherUserFollowerAccounts(Integer targetUserId, Integer currentUserId);
+
     void addFollowRelation(Integer followerId, Integer followingId);
 
     void removeFollowRelation(Integer followerId, Integer followingId);

--- a/backend/src/main/java/com/example/backend/profile/service/impl/FollowQueryServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/profile/service/impl/FollowQueryServiceImpl.java
@@ -145,6 +145,120 @@ public class FollowQueryServiceImpl implements FollowQueryService {
         }
     }
 
+    //　他のユーザーのフォロー一覧を取得
+    @Override
+    public List<FollowingProfileResponse> getOtherUserFollowingAccounts(Integer targetUserId, Integer currentUserId) {
+        try {
+            // 1) targetUserがフォローしている相手ID一覧
+            List<FollowRelationEntity> relations = followRelationRepository.findByFollowerId(targetUserId);
+            if (relations.isEmpty()) return List.of();
+
+            List<Integer> followingIds = relations.stream()
+                    .map(FollowRelationEntity::getFollowingId)
+                    .distinct()
+                    .toList();
+
+            // 2) 相手プロフィールをまとめて取得
+            List<UserProfileEntity> profiles = profileRepository.findByUserIdIn(followingIds);
+
+            Map<Integer, UserProfileEntity> profileMap = profiles.stream()
+                    .collect(Collectors.toMap(UserProfileEntity::getUserId, Function.identity(), (a, b) -> a));
+
+            // 3) isFollowing を判定（currentUser → 相手）
+            Set<Integer> actuallyFollowing = followRelationRepository
+                    .findByFollowerIdAndFollowingIdIn(currentUserId, followingIds)
+                    .stream()
+                    .map(FollowRelationEntity::getFollowingId)
+                    .collect(Collectors.toSet());
+
+            // 4) isFollower を判定（相手 → currentUser）
+            Set<Integer> actuallyFollowers = followRelationRepository
+                    .findByFollowerIdInAndFollowingId(followingIds, currentUserId)
+                    .stream()
+                    .map(FollowRelationEntity::getFollowerId)
+                    .collect(Collectors.toSet());
+
+            List<FollowingProfileResponse> result = new ArrayList<>();
+            for (Integer fid : followingIds) {
+                UserProfileEntity p = profileMap.get(fid);
+                if (p == null) {
+                    continue;
+                }
+                result.add(new FollowingProfileResponse(
+                        fid,
+                        p.getNickname(),
+                        p.getShowUserId(),
+                        actuallyFollowing.contains(fid),
+                        actuallyFollowers.contains(fid),
+                        fileControlHelper.getFileUrl(p.getIconObjectKey())
+                ));
+            }
+            log.info("他ユーザーのフォロー一覧を取得しました targetUserId: {}, currentUserId: {}", targetUserId, currentUserId);
+            return result;
+
+        } catch (Exception e) {
+            log.error("他ユーザーのフォロー一覧の取得に失敗しました: ", e);
+            throw new IllegalArgumentException("他ユーザーのフォロー一覧の取得に失敗しました");
+        }
+    }
+
+    // 他のユーザーのフォロワー一覧を取得
+    @Override
+    public List<FollowingProfileResponse> getOtherUserFollowerAccounts(Integer targetUserId, Integer currentUserId) {
+        try {
+            // 1) targetUserをフォローしている相手ID一覧
+            List<FollowRelationEntity> relations = followRelationRepository.findByFollowingId(targetUserId);
+            if (relations.isEmpty()) return List.of();
+
+            List<Integer> followerIds = relations.stream()
+                    .map(FollowRelationEntity::getFollowerId)
+                    .distinct()
+                    .toList();
+
+            // 2) 相手プロフィールをまとめて取得
+            List<UserProfileEntity> profiles = profileRepository.findByUserIdIn(followerIds);
+
+            Map<Integer, UserProfileEntity> profileMap = profiles.stream()
+                    .collect(Collectors.toMap(UserProfileEntity::getUserId, Function.identity(), (a, b) -> a));
+
+            // 3) isFollowing を判定（currentUser → 相手）
+            Set<Integer> actuallyFollowing = followRelationRepository
+                    .findByFollowerIdAndFollowingIdIn(currentUserId, followerIds)
+                    .stream()
+                    .map(FollowRelationEntity::getFollowingId)
+                    .collect(Collectors.toSet());
+
+            // 4) isFollower を判定（相手 → currentUser）
+            Set<Integer> actuallyFollowers = followRelationRepository
+                    .findByFollowerIdInAndFollowingId(followerIds, currentUserId)
+                    .stream()
+                    .map(FollowRelationEntity::getFollowerId)
+                    .collect(Collectors.toSet());
+
+            List<FollowingProfileResponse> result = new ArrayList<>();
+            for (Integer fid : followerIds) {
+                UserProfileEntity p = profileMap.get(fid);
+                if (p == null) {
+                    continue;
+                }
+                result.add(new FollowingProfileResponse(
+                        fid,
+                        p.getNickname(),
+                        p.getShowUserId(),
+                        actuallyFollowing.contains(fid),
+                        actuallyFollowers.contains(fid),
+                        fileControlHelper.getFileUrl(p.getIconObjectKey())
+                ));
+            }
+            log.info("他ユーザーのフォロワー一覧を取得しました targetUserId: {}, currentUserId: {}", targetUserId, currentUserId);
+            return result;
+
+        } catch (Exception e) {
+            log.error("他ユーザーのフォロワー一覧の取得に失敗しました: ", e);
+            throw new IllegalArgumentException("他ユーザーのフォロワー一覧の取得に失敗しました");
+        }
+    }
+
     // フォロー関係の追加
     @Override
     public void addFollowRelation(Integer followerId, Integer followingId) {


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントするときは日本語でお願いします。 -->

## 対象イシュー

<!-- 関連するIssueやチケットのリンクを貼る。close #イシュー番号でPRが閉じたタイミングでイシューを閉じれる -->

### イシューリンク

### イシュー番号(自動クローズ用)

close #221 

## やったこと
いいね・ブックマーク機能にグループの所属確認を作成
投稿機能の一部関数に教師用の表示権限確認を作成


<!-- このPRで何をしたのか？ -->

- このプルリクで何をしたのか？

## やらないこと

<!-- このPRでやらないことは何か？ -->

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？　そもそも行ったのか？

## 影響範囲

<!-- 影響を及ぼす範囲や他の機能への影響 -->

- ない場合は「無し」

## テスト

<!-- テスト方法や結果 -->

- ない場合は「無し」

## 備考
起動、動作は確認できましたが問題等起こったら教えてください
教師用の場合、自分の所属している学校以外の投稿を取得しようとしたばあい、除外ではなくエラーを吐く方式に変更しました
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
